### PR TITLE
Add additional response data for channel sorting

### DIFF
--- a/src/models/thread.model.js
+++ b/src/models/thread.model.js
@@ -25,6 +25,8 @@ const threadSchema = mongoose.Schema(
       ref: 'Topic',
       required: true,
     },
+    messages: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'Message' }],
+    followers: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'Follower' }]
   },
   {
     timestamps: true,

--- a/src/models/topic.model.js
+++ b/src/models/topic.model.js
@@ -20,6 +20,7 @@ const topicSchema = mongoose.Schema(
       required: true,
       private: true,
     },
+    threads: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'Thread' }]
   },
   {
     timestamps: true,

--- a/src/routes/v1/topics.route.js
+++ b/src/routes/v1/topics.route.js
@@ -5,7 +5,77 @@ const auth = require('../../middlewares/auth');
 const router = express.Router();
 
 router.route('/').post(auth('createTopic'), topicController.createTopic);
+
+/**
+ * @swagger
+ * tags:
+ *   name: Topic
+ *   description: Manage application Topics
+ */
+
+/**
+ * @swagger
+ * definitions:
+ *   Topic:
+ *     properties:
+ *       name:
+ *         type: string
+ *       slug:
+ *         type: string
+ *       id:
+ *         type: string
+ *       latestMessageCreatedAt:
+ *         type: string
+ *       messageCount:
+ *         type: number
+ *       follows:
+ *         type: number
+ *       defaultSortAverage:
+ *         type: number
+ */
+
+/**
+ * @swagger
+ * /topics/userTopics:
+ *   get:
+ *     description: Returns all topics for current user
+ *     tags: [Topic]
+ *     produces:
+ *      - application/json
+ *     responses:
+ *       200:
+ *         description: topic array
+ *         content: 
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 $ref: '#/definitions/Topic'
+ *                      
+ */
 router.route('/userTopics').get(auth('userTopics'), topicController.userTopics);
+
+/**
+ * @swagger
+ * /topics:
+ *   get:
+ *     description: Returns all public topics
+ *     tags: [Topic]
+ *     produces:
+ *      - application/json
+ *     responses:
+ *       200:
+ *         description: topic array
+ *         content: 
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 $ref: '#/definitions/Topic'
+ *                      
+ */
 router.route('/').get(auth('publicTopics'), topicController.allPublic);
 router.route('/:topicId').get(topicController.getTopic);
 

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -17,6 +17,9 @@ const createMessage = async (messageBody, user) => {
     owner: user,
   });
 
+  thread.messages.push(message);
+  thread.save();
+
   return message;
 };
 

--- a/src/services/thread.service.js
+++ b/src/services/thread.service.js
@@ -17,6 +17,9 @@ const createThread = async (threadBody, user) => {
     topic,
   });
 
+  topic.threads.push(thread);
+  topic.save();
+
   return thread;
 };
 
@@ -29,7 +32,7 @@ const userThreads = async (user) => {
 };
 
 const findById = async (id) => {
-  const thread = await Thread.findOne({ _id: id }).select('name slug').exec();
+  const thread = await Thread.findOne({ _id: id }).populate('followers').select('name slug').exec();
   return thread;
 };
 
@@ -52,7 +55,10 @@ const follow = async (status, threadId, user) => {
   };
 
   if (status === true) {
-    await Follower.create(params);
+    const follower = await Follower.create(params);
+
+    thread.followers.push(follower);
+    thread.save();
   } else {
     await Follower.deleteMany(params);
   }

--- a/src/services/topic.service.js
+++ b/src/services/topic.service.js
@@ -29,13 +29,15 @@ const allPublic = async () => {
 };
 
 const topicsWithSortData = async(topicQuery) => {
-  const dbtopics = await Topic.find(topicQuery)
+  const dbtopics = await Topic.find(topicQuery) 
   // Populate threads and messages for calculation of sorting properties
   .populate({
     path: 'threads',
     select: 'id',
-    populate: { path: 'messages', select: ['id','createdAt'] },
-    populate: { path: 'followers', select: 'id' }
+    populate: [
+      { path: 'messages', select: ['id','createdAt'] },
+      { path: 'followers', select: 'id' }
+    ]
   })
   .select('name slug')
   .exec();
@@ -49,7 +51,6 @@ const topicsWithSortData = async(topicQuery) => {
     let msgCount = 0;
     let followerCount = 0;
     t.threads.forEach((thread) => { 
-      console.log(thread);
       if (thread.messages && thread.messages.length > 0) {
         // Get the createdAt datetime for the final message,
         // which will always be the most recent as it is pushed
@@ -58,6 +59,7 @@ const topicsWithSortData = async(topicQuery) => {
         // Sum up the messages and followers for all threads
         msgCount += thread.messages.length;
       }
+      // Sum up followers for all threads
       if (thread.followers && thread.followers.length > 0)
         followerCount += thread.followers.length;
     })
@@ -76,6 +78,8 @@ const topicsWithSortData = async(topicQuery) => {
     topic.defaultSortAverage = 0;
     if (topic.latestMessageCreatedAt && topic.messageCount) {
       const msSinceEpoch = new Date(topic.latestMessageCreatedAt).getTime();
+      console.log('msSinceEpoch', msSinceEpoch);
+      console.log('topic.messageCount', topic.messageCount);
       topic.defaultSortAverage = msSinceEpoch * topic.messageCount;
     }
     

--- a/src/services/topic.service.js
+++ b/src/services/topic.service.js
@@ -14,7 +14,7 @@ const createTopic = async (topicBody, user) => {
 };
 
 const userTopics = async (user) => {
-  const topics = await Topic.find({ owner: user }).select('name slug').exec();
+  const topics = await topicsWithSortData({ owner: user });
   return topics;
 };
 
@@ -24,7 +24,64 @@ const findById = async (id) => {
 };
 
 const allPublic = async () => {
-  const topics = await Topic.find().select('name slug').exec();
+  const topics = await topicsWithSortData();
+  return topics;
+};
+
+const topicsWithSortData = async(topicQuery) => {
+  const dbtopics = await Topic.find(topicQuery)
+  // Populate threads and messages for calculation of sorting properties
+  .populate({
+    path: 'threads',
+    select: 'id',
+    populate: { path: 'messages', select: ['id','createdAt'] },
+    populate: { path: 'followers', select: 'id' }
+  })
+  .select('name slug')
+  .exec();
+
+  const topics = [];
+  dbtopics.forEach((t) => {
+    // Create a new POJO for return, since mongoose
+    // does not allow for random properties to be set.
+    const topic = {};
+    const threadMsgTimes = [];
+    let msgCount = 0;
+    let followerCount = 0;
+    t.threads.forEach((thread) => { 
+      console.log(thread);
+      if (thread.messages && thread.messages.length > 0) {
+        // Get the createdAt datetime for the final message,
+        // which will always be the most recent as it is pushed
+        // to Thread.messages upon message creation.
+        threadMsgTimes.push(thread.messages.slice(-1)[0].createdAt);
+        // Sum up the messages and followers for all threads
+        msgCount += thread.messages.length;
+      }
+      if (thread.followers && thread.followers.length > 0)
+        followerCount += thread.followers.length;
+    })
+    topic.name = t.name;
+    topic.slug = t.slug;
+    topic.id = t.id;
+    // Sort the most recent messages for all threads, to determine the
+    // most recent message for the topic/channel.
+    threadMsgTimes.sort(function(a, b) {
+      return (a < b) ? 1 : ((a > b) ? -1 : 0);
+    });
+    topic.latestMessageCreatedAt = threadMsgTimes.length > 0 ? threadMsgTimes[0] : null;
+    topic.messageCount = msgCount;
+    topic.follows = followerCount;
+    // Calculate default sort avg as (message activity x recency)
+    topic.defaultSortAverage = 0;
+    if (topic.latestMessageCreatedAt && topic.messageCount) {
+      const msSinceEpoch = new Date(topic.latestMessageCreatedAt).getTime();
+      topic.defaultSortAverage = msSinceEpoch * topic.messageCount;
+    }
+    
+    topics.push(topic);
+  })
+
   return topics;
 };
 


### PR DESCRIPTION
- Updated Topic and Thread models to leverage [Mongoose populate](https://mongoosejs.com/docs/populate.html) feature; also updated associated services to push messages, threads, and followers during POST events
- Added `topicsWithSortData` function, which uses the Mongoose populate feature to pull in statistics on messages and followers
- Updated `/topics` and `/topics/usertopics` routes to use the new function and send back statistics for sorting (message count, follower count, last message created, default sort (msg count * last msg created)
- Added Swagger definitions for updates routes