### PR TITLE
Add support for voting on threads

### DIFF
--- a/src/config/roles.js
+++ b/src/config/roles.js
@@ -11,6 +11,8 @@ const allRoles = {
     'publicTopics',
     'publicThreads',
     'deleteThread',
+    'upVote',
+    'downVote'
   ],
   admin: ['getUsers', 'manageUsers'],
 };

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -7,12 +7,14 @@ const register = catchAsync(async (req, res) => {
     throw new Error('Invalid login token');
   }
   const user = await userService.createUser(req.body);
+  user.goodReputation = await userService.goodReputation(user);
   const tokens = await tokenService.generateAuthTokens(user);
   res.status(httpStatus.CREATED).send({ user, tokens });
 });
 
 const login = catchAsync(async (req, res) => {
   const user = await authService.loginUser(req.body);
+  user.goodReputation = await userService.goodReputation(user);
   const tokens = await tokenService.generateAuthTokens(user);
   res.send({ user, tokens });
 });

--- a/src/controllers/message.controller.js
+++ b/src/controllers/message.controller.js
@@ -12,7 +12,19 @@ const threadMessages = catchAsync(async (req, res) => {
   res.status(httpStatus.OK).send(messages);
 });
 
+const upVote = catchAsync(async (req, res) => {
+  await messageService.vote(req.params.messageId, 'up');
+  res.status(httpStatus.OK).send();
+});
+
+const downVote = catchAsync(async (req, res) => {
+  await messageService.vote(req.params.messageId, 'down');
+  res.status(httpStatus.OK).send();
+});
+
 module.exports = {
   createMessage,
   threadMessages,
+  upVote,
+  downVote
 };

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -5,11 +5,13 @@ const { userService } = require('../services');
 
 const createUser = catchAsync(async (req, res) => {
   const user = await userService.createUser(req.body);
+  user.goodReputation = await userService.goodReputation(user);
   res.status(httpStatus.CREATED).send(user);
 });
 
 const getUser = catchAsync(async (req, res) => {
   const user = await userService.getUserById(req.params.userId);
+  user.goodReputation = await userService.goodReputation(user);
   if (!user) {
     throw new ApiError(httpStatus.NOT_FOUND, 'User not found');
   }

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -22,6 +22,8 @@ components:
         role:
           type: string
           enum: [user, admin]
+        goodReputation:
+          type: boolean
         createdAt:
           type: date
         pseudonyms:
@@ -33,6 +35,7 @@ components:
         username: fake@example.com
         name: fake name
         role: user
+        goodReputation: true
         createdAt: 2021-11-30T01:51:01.639Z
         pseudonyms:  
           - token: b019d20aa74a16c8c68701cc2937c8a76bc6cdc6247d51cf80bb3d1f27f6ac3f9dec9c0dbe80543f8d2c40428c84576cc3a644668be5b3156be070f57be0521a13c3f6f42a8d2c8ef13f92e092236f4e

--- a/src/models/message.model.js
+++ b/src/models/message.model.js
@@ -18,6 +18,14 @@ const messageSchema = mongoose.Schema(
       ref: 'Thread',
       required: true,
     },
+    upVotes: {
+      type: Number,
+      default: 0
+    },
+    downVotes: {
+      type: Number,
+      default: 0
+    }
   },
   {
     timestamps: true,

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -42,6 +42,9 @@ const userSchema = mongoose.Schema(
       enum: roles,
       default: 'user',
     },
+    goodReputation: {
+      type: Boolean
+    }
   },
   {
     timestamps: true,

--- a/src/routes/v1/messages.route.js
+++ b/src/routes/v1/messages.route.js
@@ -6,7 +6,54 @@ const auth = require('../../middlewares/auth');
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * tags:
+ *   name: Message
+ *   description: Manage application Messages
+ */
+
 router.post('/', auth('createMessage'), validate(messageValidation.createMessage), messageController.createMessage);
 router.route('/:threadId').get(messageController.threadMessages);
+
+/**
+ * @swagger
+ * /messages/{messageId}/upVote:
+ *   post:
+ *     description: Upvote a message
+ *     tags: [Message]
+ *     parameters:
+ *       - in: path
+ *         name: messageId
+ *         required: true
+ *         description: Id of message to apply vote to.
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: ok
+ *                      
+ */
+router.route('/:messageId/upVote').post(auth('upVote'), messageController.upVote);
+
+/**
+ * @swagger
+ * /messages/{messageId}/downVote:
+ *   post:
+ *     description: Downvote a message
+ *     parameters:
+ *       - in: path
+ *         name: messageId
+ *         required: true
+ *         description: Id of message to apply vote to.
+ *         schema:
+ *           type: string
+ *     tags: [Message]
+ *     responses:
+ *       200:
+ *         description: ok
+ *                      
+ */
+router.route('/:messageId/downVote').post(auth('downVote'), messageController.downVote);
 
 module.exports = router;

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -10,14 +10,13 @@ const { Thread } = require('../models');
 const createMessage = async (messageBody, user) => {
   const threadId = mongoose.Types.ObjectId(messageBody.thread);
   const thread = await Thread.findById(threadId);
-
   const message = await Message.create({
     body: messageBody.body,
     thread,
     owner: user,
   });
 
-  thread.messages.push(message);
+  thread.messages.push(message.toObject());
   thread.save();
 
   return message;

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -28,7 +28,25 @@ const threadMessages = async (id) => {
   return messages;
 };
 
+/**
+ * Upvote or downvote a message
+ * @param {Object} messageId
+ * @param {Object} direction
+ * @returns {Promise<void>}
+ */
+const vote = async (messageId, direction) => {
+  const message = await Message.findById(messageId);
+  if (direction === 'up') {
+    message.upVotes++;
+  } else {
+    message.downVotes++;
+  }
+
+  await message.save();
+};
+
 module.exports = {
   createMessage,
   threadMessages,
+  vote
 };

--- a/src/services/thread.service.js
+++ b/src/services/thread.service.js
@@ -17,7 +17,7 @@ const createThread = async (threadBody, user) => {
     topic,
   });
 
-  topic.threads.push(thread);
+  topic.threads.push(thread.toObject());
   topic.save();
 
   return thread;
@@ -57,7 +57,7 @@ const follow = async (status, threadId, user) => {
   if (status === true) {
     const follower = await Follower.create(params);
 
-    thread.followers.push(follower);
+    thread.followers.push(follower.toObject());
     thread.save();
   } else {
     await Follower.deleteMany(params);

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -1,6 +1,7 @@
 const httpStatus = require('http-status');
 const crypto = require('crypto');
 const { User } = require('../models');
+const { Message } = require('../models');
 const ApiError = require('../utils/ApiError');
 const { uniqueNamesGenerator, adjectives, colors, animals } = require('unique-names-generator');
 
@@ -108,14 +109,14 @@ const newToken = () => {
   const cipher = crypto.createCipher(algorithm, key);
   const encrypted = cipher.update(data, 'utf8', 'hex') + cipher.final('hex');
   return encrypted;
-}
+};
 
 const newPseudonym = () => {
   const pseudo = uniqueNamesGenerator({ dictionaries: [adjectives, animals], length: 2 });
   return pseudo.split('_').map((word) => {
     return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase()
   }).join(' ');;
-}
+};
 
 const isTokenGeneratedByThreads = (password) => {
   const algorithm = 'aes256';
@@ -127,6 +128,30 @@ const isTokenGeneratedByThreads = (password) => {
   return typeof decryptedParsed.token !== 'undefined';
 };
 
+/**
+ * Check if a user has good "reputation"
+ * @param {User} user
+ * @returns {Promise<boolean>}
+ */
+const goodReputation = async (user) => {
+  // Calculate total downvotes for all user's messages
+  const messages = await Message.find({ owner: user.id});
+  let totalDownVotes = 0;
+  if (messages.length > 0) {
+    totalDownVotes = messages.map((m) => {
+      const downVotes = m.downVotes ? m.downVotes : 0;
+      return downVotes;
+    }).reduce((x, y) => x + y);
+  }
+  // Calculate weeks since account creation
+  const today = new Date();
+  const createdDate = new Date(user.createdAt);
+  const weeks = Math.round((today - createdDate) / 604800000);
+  // Good reputation is a user with less than 5 total downvotes,
+  // and an account more than 1 week old.
+  return ((totalDownVotes <= 5) && (weeks > 0));
+};
+
 module.exports = {
   createUser,
   queryUsers,
@@ -136,5 +161,6 @@ module.exports = {
   getUserByUsernamePassword,
   isTokenGeneratedByThreads,
   newToken,
-  newPseudonym
+  newPseudonym,
+  goodReputation
 };

--- a/src/validations/user.validation.js
+++ b/src/validations/user.validation.js
@@ -3,7 +3,10 @@ const { password, objectId } = require('./custom.validation');
 
 const createUser = {
   body: Joi.object().keys({
-    password: Joi.string().required().custom(password),
+    username: Joi.string(),
+    password: Joi.string().custom(password),
+    pseudonym: Joi.string().required(),
+    token: Joi.string().required(),
   }),
 };
 

--- a/tests/fixtures/message.fixture.js
+++ b/tests/fixtures/message.fixture.js
@@ -1,0 +1,27 @@
+const mongoose = require('mongoose');
+const faker = require('faker');
+const Message = require('../../src/models/message.model');
+const { userOne } = require('./user.fixture');
+const { threadOne } = require('./thread.fixture');
+
+const messageOne = {
+    _id: mongoose.Types.ObjectId(),
+    body: faker.lorem.words(10),
+    thread: mongoose.Types.ObjectId(),
+    owner: userOne._id,
+};
+
+const messageTwo = {
+    body: faker.lorem.words(10),
+    thread: threadOne._id,
+};
+
+const insertMessages = async (msgs) => {
+  await Message.insertMany(msgs);
+};
+
+module.exports = {
+  messageOne,
+  messageTwo,
+  insertMessages,
+};

--- a/tests/fixtures/thread.fixture.js
+++ b/tests/fixtures/thread.fixture.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+const faker = require('faker');
+const Thread = require('../../src/models/thread.model');
+const { userOne } = require('./user.fixture');
+const { topicOne } = require('./topic.fixture');
+
+
+const nameSlug = faker.lorem.word().toLowerCase();
+
+const threadOne = {
+    _id: mongoose.Types.ObjectId(),
+    name: nameSlug,
+    slug: nameSlug,
+    owner: userOne._id,
+    topic: topicOne._id,
+};
+
+const insertThreads = async (threads) => {
+  await Thread.insertMany(threads);
+};
+
+module.exports = {
+  threadOne,
+  insertThreads,
+};

--- a/tests/fixtures/topic.fixture.js
+++ b/tests/fixtures/topic.fixture.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+const faker = require('faker');
+const Topic = require('../../src/models/topic.model');
+const { userOne } = require('./user.fixture');
+
+const nameSlug = faker.lorem.word().toLowerCase();
+
+const topicOne = {
+    _id: mongoose.Types.ObjectId(),
+    name: nameSlug,
+    slug: nameSlug,
+    owner: userOne._id,
+};
+
+const insertTopics = async (topics) => {
+  await Topic.insertMany(topics);
+};
+
+module.exports = {
+  topicOne,
+  insertTopics,
+};

--- a/tests/integration/message.test.js
+++ b/tests/integration/message.test.js
@@ -1,0 +1,62 @@
+const setupTestDB = require('../utils/setupTestDB');
+const { messageOne, insertMessages, messageTwo } = require('../fixtures/message.fixture');
+const app = require('../../src/app');
+const request = require('supertest');
+const { insertUsers, userOne } = require('../fixtures/user.fixture');
+const { userOneAccessToken } = require('../fixtures/token.fixture');
+const httpStatus = require('http-status');
+const Message = require('../../src/models/message.model');
+const { insertTopics, topicOne } = require('../fixtures/topic.fixture');
+const { threadOne, insertThreads } = require('../fixtures/thread.fixture');
+
+setupTestDB();
+
+describe('Message routes', () => {
+    describe('POST /v1/messages/:threadId/upVote', () => {
+        test('should return 200 and increment upVote count for message', async () => {
+            await insertUsers([userOne]);
+            const messageId = messageOne._id;
+            await insertMessages([messageOne]);
+            await request(app)
+                .post(`/v1/messages/${messageId}/upVote`)
+                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .send()
+                .expect(httpStatus.OK);
+
+            const msg = await Message.findById(messageId);
+            expect(msg.upVotes).toBe(1);
+        });
+    });
+
+    describe('POST /v1/messages/:threadId/downVote', () => {
+        test('should return 200 and increment downVote count for message', async () => {
+            await insertUsers([userOne]);
+            const messageId = messageOne._id;
+            await insertMessages([messageOne]);
+            await request(app)
+                .post(`/v1/messages/${messageId}/downVote`)
+                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .send()
+                .expect(httpStatus.OK);
+
+            const msg = await Message.findById(messageId);
+            expect(msg.downVotes).toBe(1);
+        });
+    });
+
+    describe('POST /v1/messages', () => {
+        test('should return 201 and create message', async () => {
+            await insertUsers([userOne]);
+            await insertTopics([topicOne]);
+            await insertThreads([threadOne]);
+            const res =  await request(app)
+                .post(`/v1/messages/`)
+                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .send(messageTwo)
+                .expect(httpStatus.CREATED);
+
+            const msgs = await Message.find({ id: res.id });
+            expect(msgs.length).toBe(1);
+        });
+    });
+});


### PR DESCRIPTION
- Added `/messages/upVote` and `/messages/downVote` endpoints to support message voting
- Added new property `goodReputation` to all user objects returned by API (login, register, etc.), which can be used to determine if a user can downvote messages
- Wrote new tests for message endpoints; fixed a few issues with populated fields in Mongo that were revealed by running tests

**Note on tests**: The user and auth tests are currently broken (also true in `main` branch). If there is time left, I will go back and fix those tests. For now, to run the new Message tests, use the following command.

`jest -i --colors --verbose --forceExit tests/integration/message.test.js`