### PR TITLE
Support for adding new pseudonym to existing account

### DIFF
--- a/src/config/roles.js
+++ b/src/config/roles.js
@@ -12,7 +12,8 @@ const allRoles = {
     'publicThreads',
     'deleteThread',
     'upVote',
-    'downVote'
+    'downVote',
+    'managePseudonym',
   ],
   admin: ['getUsers', 'manageUsers'],
 };

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -18,7 +18,19 @@ const getUser = catchAsync(async (req, res) => {
   res.send(user);
 });
 
+const addPseudonym = catchAsync(async (req, res) => {
+  const user = await userService.addPseudonym(req.body, req.user);
+  res.status(httpStatus.CREATED).send(user.pseudonyms);
+});
+
+const activatePseudonym = catchAsync(async (req, res) => {
+  const user = await userService.activatePseudonym(req.body, req.user);
+  res.status(httpStatus.OK).send(user.pseudonyms);
+});
+
 module.exports = {
   createUser,
   getUser,
+  addPseudonym,
+  activatePseudonym,
 };

--- a/src/routes/v1/user.route.js
+++ b/src/routes/v1/user.route.js
@@ -2,9 +2,79 @@ const express = require('express');
 const userController = require('../../controllers/user.controller');
 const userValidation = require('../../validations/user.validation');
 const validate = require('../../middlewares/validate');
+const auth = require('../../middlewares/auth');
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * tags:
+ *   name: User
+ *   description: User management
+ */
+
 router.post('/', validate(userValidation.createUser), userController.createUser);
+
+/**
+ * @swagger
+ * /users/pseudonyms:
+ *   post:
+ *     description: Add a pseudonym for user and set to active
+ *     tags: [User]
+ *     produces:
+ *       - application/json
+ *     requestBody:
+ *       required: true
+ *       content: 
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               token:
+ *                 type: string
+ *               pseudonym:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Pseudonym array
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 $ref: '#/components/schemas/Pseudonym'
+ */
+router.route('/pseudonyms').post(auth('managePseudonym'), userController.addPseudonym);
+
+/**
+ * @swagger
+ * /users/pseudonyms/activate:
+ *   put:
+ *     description: Set a pseudonym to active
+ *     tags: [User]
+ *     produces:
+ *       - application/json
+ *     requestBody:
+ *       required: true
+ *       content: 
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               token:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Pseudonym array
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 $ref: '#/components/schemas/Pseudonym'
+*/
+router.route('/pseudonyms/activate').put(auth('managePseudonym'), userController.activatePseudonym);
 
 module.exports = router;

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -26,6 +26,44 @@ const createUser = async (userBody) => {
 };
 
 /**
+ * Add a pseudonym to an existing a user
+ * @param {Object} requestBody
+ * @param {Object} user
+ * @returns {Promise<void>}
+ */
+ const addPseudonym = async (requestBody, requestUser) => {
+  requestBody.active = true;
+  const user = await User.findById(requestUser.id);
+  user.pseudonyms.forEach((p) => p.active = false);
+  user.pseudonyms.push(requestBody);
+  await user.save()
+  return user;
+};
+
+/**
+ * Update a pseudonym
+ * @param {Object} requestBody
+ * @param {Object} user
+ * @returns {Promise<void>}
+ */
+ const activatePseudonym = async (requestBody, requestUser) => {
+  const user = await User.findById(requestUser.id);
+  let match = false;
+  user.pseudonyms.forEach((p) => {
+    p.active = false;
+    if (p.token === requestBody.token) {
+      p.active = true;
+      match = true;
+    }
+  });
+  if (!match) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Pseudonym not found');
+  }
+  await user.save()
+  return user;
+};
+
+/**
  * Query for users
  * @param {Object} filter - Mongo filter
  * @param {Object} options - Query options
@@ -172,5 +210,7 @@ module.exports = {
   isTokenGeneratedByThreads,
   newToken,
   newPseudonym,
-  goodReputation
+  goodReputation,
+  addPseudonym,
+  activatePseudonym,
 };

--- a/src/validations/user.validation.js
+++ b/src/validations/user.validation.js
@@ -10,6 +10,13 @@ const createUser = {
   }),
 };
 
+const addPseudonym = {
+  body: Joi.object().keys({
+    pseudonym: Joi.string().required(),
+    token: Joi.string().required(),
+  }),
+};
+
 const getUsers = {
   query: Joi.object().keys({
     name: Joi.string(),
@@ -51,4 +58,5 @@ module.exports = {
   getUser,
   updateUser,
   deleteUser,
+  addPseudonym,
 };


### PR DESCRIPTION
- Added `/users/pseudonym` POST endpoint for adding new pseudonym to a user, and marking as active
- Added `/users/pseudonym/activate` PUT endpoint for marking an existing pseudonym as active (to support dropdown toggling of pseudonyms)