### PR TITLE
Ensure that pseudonyms are attached to messages for proper display

### DIFF
--- a/src/models/message.model.js
+++ b/src/models/message.model.js
@@ -20,12 +20,20 @@ const messageSchema = mongoose.Schema(
     },
     upVotes: {
       type: Number,
-      default: 0
+      default: 0,
     },
     downVotes: {
       type: Number,
-      default: 0
-    }
+      default: 0,
+    },
+    pseudonym: {
+      type: String,
+      required: true,
+    },
+    pseudonymId: {
+      type: mongoose.SchemaTypes.ObjectId,
+      required: true,
+    },
   },
   {
     timestamps: true,

--- a/src/routes/v1/messages.route.js
+++ b/src/routes/v1/messages.route.js
@@ -14,6 +14,40 @@ const router = express.Router();
  */
 
 router.post('/', auth('createMessage'), validate(messageValidation.createMessage), messageController.createMessage);
+
+/**
+ * @swagger
+ * /messages:
+ *   get:
+ *     description: Returns all thread messages
+ *     tags: [Message]
+ *     produces:
+ *      - application/json
+ *     responses:
+ *       200:
+ *         description: message array
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                   upVotes:
+ *                     type: number
+ *                   downVotes:
+ *                     type: number
+ *                   body:
+ *                     type: string
+ *                   owner:
+ *                     type: string
+ *                   pseudonym:
+ *                     type: string
+ *                   createdAt:
+ *                     type: string
+ */
 router.route('/:threadId').get(messageController.threadMessages);
 
 /**

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -10,10 +10,13 @@ const { Thread } = require('../models');
 const createMessage = async (messageBody, user) => {
   const threadId = mongoose.Types.ObjectId(messageBody.thread);
   const thread = await Thread.findById(threadId);
+  const activePseudo = user.pseudonyms.find(x => x.active);
   const message = await Message.create({
     body: messageBody.body,
     thread,
     owner: user,
+    pseudonym: activePseudo.pseudonym,
+    pseudonymId: activePseudo._id
   });
 
   thread.messages.push(message.toObject());
@@ -23,7 +26,10 @@ const createMessage = async (messageBody, user) => {
 };
 
 const threadMessages = async (id) => {
-  const messages = await Message.find({ thread: id }).select('body owner createdAt').sort({ createdAt: 1 }).exec();
+  const messages = await Message.find({ thread: id })
+    .select('body owner upVotes downVotes pseudonym createdAt')
+    .sort({ createdAt: 1 })
+    .exec();
   return messages;
 };
 

--- a/tests/fixtures/message.fixture.js
+++ b/tests/fixtures/message.fixture.js
@@ -1,14 +1,14 @@
 const mongoose = require('mongoose');
 const faker = require('faker');
 const Message = require('../../src/models/message.model');
-const { userOne } = require('./user.fixture');
+const { registeredUser } = require('./user.fixture');
 const { threadOne } = require('./thread.fixture');
 
 const messageOne = {
     _id: mongoose.Types.ObjectId(),
     body: faker.lorem.words(10),
     thread: mongoose.Types.ObjectId(),
-    owner: userOne._id,
+    owner: registeredUser._id,
 };
 
 const messageTwo = {

--- a/tests/fixtures/token.fixture.js
+++ b/tests/fixtures/token.fixture.js
@@ -2,13 +2,15 @@ const moment = require('moment');
 const config = require('../../src/config/config');
 const { tokenTypes } = require('../../src/config/tokens');
 const tokenService = require('../../src/services/token.service');
-const { userOne, admin } = require('./user.fixture');
+const { userOne, admin, registeredUser } = require('./user.fixture');
 
 const accessTokenExpires = moment().add(config.jwt.accessExpirationMinutes, 'minutes');
 const userOneAccessToken = tokenService.generateToken(userOne._id, accessTokenExpires, tokenTypes.ACCESS);
+const registeredUserAccessToken = tokenService.generateToken(registeredUser._id, accessTokenExpires, tokenTypes.ACCESS);
 const adminAccessToken = tokenService.generateToken(admin._id, accessTokenExpires, tokenTypes.ACCESS);
 
 module.exports = {
   userOneAccessToken,
   adminAccessToken,
+  registeredUserAccessToken,
 };

--- a/tests/fixtures/user.fixture.js
+++ b/tests/fixtures/user.fixture.js
@@ -25,6 +25,21 @@ const userTwo = {
   isEmailVerified: false,
 };
 
+const registeredUser = {
+  _id: mongoose.Types.ObjectId(),
+  name: faker.name.findName(),
+  email: faker.internet.email().toLowerCase(),
+  password,
+  role: 'user',
+  isEmailVerified: false,
+  pseudonyms: [
+    {
+      token: '31c5d2b7d2b0f86b2b4b204ed4bf17938e4108a573b25db493a55c4639cc6cd3518a4c88787fe29cf9f273d61e3c5fd4eabb528e3e9b7398c1ed0944581ce51e53f6eae13328c4be05e7e14365063409',
+      pseudonym: 'Boring Badger'
+    }
+  ]
+};
+
 const admin = {
   _id: mongoose.Types.ObjectId(),
   name: faker.name.findName(),
@@ -41,6 +56,7 @@ const insertUsers = async (users) => {
 module.exports = {
   userOne,
   userTwo,
+  registeredUser,
   admin,
   insertUsers,
 };

--- a/tests/fixtures/user.fixture.js
+++ b/tests/fixtures/user.fixture.js
@@ -35,7 +35,8 @@ const registeredUser = {
   pseudonyms: [
     {
       token: '31c5d2b7d2b0f86b2b4b204ed4bf17938e4108a573b25db493a55c4639cc6cd3518a4c88787fe29cf9f273d61e3c5fd4eabb528e3e9b7398c1ed0944581ce51e53f6eae13328c4be05e7e14365063409',
-      pseudonym: 'Boring Badger'
+      pseudonym: 'Boring Badger',
+      active: 'true',
     }
   ]
 };
@@ -50,7 +51,8 @@ const admin = {
 };
 
 const insertUsers = async (users) => {
-  await User.insertMany(users.map((user) => ({ ...user, password: hashedPassword })));
+  const ret = await User.insertMany(users.map((user) => ({ ...user, password: hashedPassword })));
+  return ret;
 };
 
 module.exports = {

--- a/tests/integration/message.test.js
+++ b/tests/integration/message.test.js
@@ -60,5 +60,19 @@ describe('Message routes', () => {
             const msgs = await Message.find({ id: res.id });
             expect(msgs.length).toBe(1);
         });
+
+        test('should create message, and message should have current active pseudonym', async () => {
+            const userRet = await insertUsers([registeredUser]);
+            await insertTopics([topicOne]);
+            await insertThreads([threadOne]);
+            const res =  await request(app)
+                .post(`/v1/messages/`)
+                .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+                .send(messageTwo)
+                .expect(httpStatus.CREATED);
+
+            const msgs = await Message.find({ id: res.id });
+            expect(msgs[0].pseudonymId).toEqual(userRet[0].pseudonyms[0]._id);
+        });
     });
 });

--- a/tests/integration/message.test.js
+++ b/tests/integration/message.test.js
@@ -2,8 +2,8 @@ const setupTestDB = require('../utils/setupTestDB');
 const { messageOne, insertMessages, messageTwo } = require('../fixtures/message.fixture');
 const app = require('../../src/app');
 const request = require('supertest');
-const { insertUsers, userOne } = require('../fixtures/user.fixture');
-const { userOneAccessToken } = require('../fixtures/token.fixture');
+const { insertUsers, registeredUser } = require('../fixtures/user.fixture');
+const { registeredUserAccessToken } = require('../fixtures/token.fixture');
 const httpStatus = require('http-status');
 const Message = require('../../src/models/message.model');
 const { insertTopics, topicOne } = require('../fixtures/topic.fixture');
@@ -14,44 +14,46 @@ setupTestDB();
 describe('Message routes', () => {
     describe('POST /v1/messages/:threadId/upVote', () => {
         test('should return 200 and increment upVote count for message', async () => {
-            await insertUsers([userOne]);
-            const messageId = messageOne._id;
+            const userRet = await insertUsers([registeredUser]);
+            messageOne.pseudonymId = userRet[0].pseudonyms[0]._id;
+            messageOne.pseudonym = userRet[0].pseudonyms[0].pseudonym;
             await insertMessages([messageOne]);
             await request(app)
-                .post(`/v1/messages/${messageId}/upVote`)
-                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .post(`/v1/messages/${messageOne._id}/upVote`)
+                .set('Authorization', `Bearer ${registeredUserAccessToken}`)
                 .send()
                 .expect(httpStatus.OK);
 
-            const msg = await Message.findById(messageId);
+            const msg = await Message.findById(messageOne._id);
             expect(msg.upVotes).toBe(1);
         });
     });
 
     describe('POST /v1/messages/:threadId/downVote', () => {
         test('should return 200 and increment downVote count for message', async () => {
-            await insertUsers([userOne]);
-            const messageId = messageOne._id;
+            const userRet = await insertUsers([registeredUser]);
+            messageOne.pseudonymId = userRet[0].pseudonyms[0]._id;
+            messageOne.pseudonym = userRet[0].pseudonyms[0].pseudonym;
             await insertMessages([messageOne]);
             await request(app)
-                .post(`/v1/messages/${messageId}/downVote`)
-                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .post(`/v1/messages/${messageOne._id}/downVote`)
+                .set('Authorization', `Bearer ${registeredUserAccessToken}`)
                 .send()
                 .expect(httpStatus.OK);
 
-            const msg = await Message.findById(messageId);
+            const msg = await Message.findById(messageOne._id);
             expect(msg.downVotes).toBe(1);
         });
     });
 
     describe('POST /v1/messages', () => {
         test('should return 201 and create message', async () => {
-            await insertUsers([userOne]);
+            await insertUsers([registeredUser]);
             await insertTopics([topicOne]);
             await insertThreads([threadOne]);
             const res =  await request(app)
                 .post(`/v1/messages/`)
-                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .set('Authorization', `Bearer ${registeredUserAccessToken}`)
                 .send(messageTwo)
                 .expect(httpStatus.CREATED);
 

--- a/tests/integration/user.test.js
+++ b/tests/integration/user.test.js
@@ -4,622 +4,668 @@ const httpStatus = require('http-status');
 const app = require('../../src/app');
 const setupTestDB = require('../utils/setupTestDB');
 const { User } = require('../../src/models');
-const { userOne, userTwo, admin, insertUsers } = require('../fixtures/user.fixture');
-const { userOneAccessToken, adminAccessToken } = require('../fixtures/token.fixture');
+const { userOne, userTwo, admin, insertUsers, registeredUser } = require('../fixtures/user.fixture');
+const { userOneAccessToken, adminAccessToken, registeredUserAccessToken } = require('../fixtures/token.fixture');
+const userService = require('../../src/services/user.service');
 
 setupTestDB();
 
 describe('User routes', () => {
-  describe('POST /v1/users', () => {
-    let newUser;
 
+  describe('POST v1/users/pseudonyms', () => {
+    let newPseudo;
     beforeEach(() => {
-      newUser = {
-        name: faker.name.findName(),
-        email: faker.internet.email().toLowerCase(),
-        password: 'password1',
-        role: 'user',
+      newPseudo = {
+        token: userService.newToken(),
+        pseudonym: userService.newPseudonym()
       };
     });
 
-    test('should return 201 and successfully create new user if data is ok', async () => {
-      await insertUsers([admin]);
+    test('should return 201 and successfully create pseudonym', async () => {
+      await insertUsers([registeredUser]);
+      const ret = await request(app)
+          .post('/v1/users/pseudonyms')
+          .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+          .send(newPseudo)
+          .expect(httpStatus.CREATED);
 
-      const res = await request(app)
-        .post('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(newUser)
-        .expect(httpStatus.CREATED);
+      const activePseudo = ret.body.find(x => x.active);
+      expect(activePseudo.token).toBe(newPseudo.token);
+    });
 
-      expect(res.body).not.toHaveProperty('password');
-      expect(res.body).toEqual({
-        id: expect.anything(),
-        name: newUser.name,
-        email: newUser.email,
-        role: newUser.role,
-        isEmailVerified: false,
+    test('should return 200 and activate pseudonym', async () => {
+      await insertUsers([registeredUser]);
+      await request(app)
+      .post('/v1/users/pseudonyms')
+      .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+      .send(newPseudo);
+
+      const ret = await request(app)
+          .put('/v1/users/pseudonyms/activate')
+          .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+          .send({
+            token: registeredUser.pseudonyms[0].token
+          })
+          .expect(httpStatus.OK);
+
+        expect(ret.body).toHaveLength(2);
+        const activePseudo = ret.body.find(x => x.active);
+        expect(activePseudo.token).toBe(registeredUser.pseudonyms[0].token);
       });
-
-      const dbUser = await User.findById(res.body.id);
-      expect(dbUser).toBeDefined();
-      expect(dbUser.password).not.toBe(newUser.password);
-      expect(dbUser).toMatchObject({ name: newUser.name, email: newUser.email, role: newUser.role, isEmailVerified: false });
-    });
-
-    test('should be able to create an admin as well', async () => {
-      await insertUsers([admin]);
-      newUser.role = 'admin';
-
-      const res = await request(app)
-        .post('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(newUser)
-        .expect(httpStatus.CREATED);
-
-      expect(res.body.role).toBe('admin');
-
-      const dbUser = await User.findById(res.body.id);
-      expect(dbUser.role).toBe('admin');
-    });
-
-    test('should return 401 error if access token is missing', async () => {
-      await request(app).post('/v1/users').send(newUser).expect(httpStatus.UNAUTHORIZED);
-    });
-
-    test('should return 403 error if logged in user is not admin', async () => {
-      await insertUsers([userOne]);
-
-      await request(app)
-        .post('/v1/users')
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(newUser)
-        .expect(httpStatus.FORBIDDEN);
-    });
-
-    test('should return 400 error if email is invalid', async () => {
-      await insertUsers([admin]);
-      newUser.email = 'invalidEmail';
-
-      await request(app)
-        .post('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(newUser)
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should return 400 error if email is already used', async () => {
-      await insertUsers([admin, userOne]);
-      newUser.email = userOne.email;
-
-      await request(app)
-        .post('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(newUser)
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should return 400 error if password length is less than 8 characters', async () => {
-      await insertUsers([admin]);
-      newUser.password = 'passwo1';
-
-      await request(app)
-        .post('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(newUser)
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should return 400 error if password does not contain both letters and numbers', async () => {
-      await insertUsers([admin]);
-      newUser.password = 'password';
-
-      await request(app)
-        .post('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(newUser)
-        .expect(httpStatus.BAD_REQUEST);
-
-      newUser.password = '1111111';
-
-      await request(app)
-        .post('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(newUser)
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should return 400 error if role is neither user nor admin', async () => {
-      await insertUsers([admin]);
-      newUser.role = 'invalid';
-
-      await request(app)
-        .post('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(newUser)
-        .expect(httpStatus.BAD_REQUEST);
-    });
-  });
-
-  describe('GET /v1/users', () => {
-    test('should return 200 and apply the default query options', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      const res = await request(app)
-        .get('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send()
-        .expect(httpStatus.OK);
-
-      expect(res.body).toEqual({
-        results: expect.any(Array),
-        page: 1,
-        limit: 10,
-        totalPages: 1,
-        totalResults: 3,
-      });
-      expect(res.body.results).toHaveLength(3);
-      expect(res.body.results[0]).toEqual({
-        id: userOne._id.toHexString(),
-        name: userOne.name,
-        email: userOne.email,
-        role: userOne.role,
-        isEmailVerified: userOne.isEmailVerified,
-      });
-    });
-
-    test('should return 401 if access token is missing', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      await request(app).get('/v1/users').send().expect(httpStatus.UNAUTHORIZED);
-    });
-
-    test('should return 403 if a non-admin is trying to access all users', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      await request(app)
-        .get('/v1/users')
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send()
-        .expect(httpStatus.FORBIDDEN);
-    });
-
-    test('should correctly apply filter on name field', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      const res = await request(app)
-        .get('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .query({ name: userOne.name })
-        .send()
-        .expect(httpStatus.OK);
-
-      expect(res.body).toEqual({
-        results: expect.any(Array),
-        page: 1,
-        limit: 10,
-        totalPages: 1,
-        totalResults: 1,
-      });
-      expect(res.body.results).toHaveLength(1);
-      expect(res.body.results[0].id).toBe(userOne._id.toHexString());
-    });
-
-    test('should correctly apply filter on role field', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      const res = await request(app)
-        .get('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .query({ role: 'user' })
-        .send()
-        .expect(httpStatus.OK);
-
-      expect(res.body).toEqual({
-        results: expect.any(Array),
-        page: 1,
-        limit: 10,
-        totalPages: 1,
-        totalResults: 2,
-      });
-      expect(res.body.results).toHaveLength(2);
-      expect(res.body.results[0].id).toBe(userOne._id.toHexString());
-      expect(res.body.results[1].id).toBe(userTwo._id.toHexString());
-    });
-
-    test('should correctly sort the returned array if descending sort param is specified', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      const res = await request(app)
-        .get('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .query({ sortBy: 'role:desc' })
-        .send()
-        .expect(httpStatus.OK);
-
-      expect(res.body).toEqual({
-        results: expect.any(Array),
-        page: 1,
-        limit: 10,
-        totalPages: 1,
-        totalResults: 3,
-      });
-      expect(res.body.results).toHaveLength(3);
-      expect(res.body.results[0].id).toBe(userOne._id.toHexString());
-      expect(res.body.results[1].id).toBe(userTwo._id.toHexString());
-      expect(res.body.results[2].id).toBe(admin._id.toHexString());
-    });
-
-    test('should correctly sort the returned array if ascending sort param is specified', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      const res = await request(app)
-        .get('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .query({ sortBy: 'role:asc' })
-        .send()
-        .expect(httpStatus.OK);
-
-      expect(res.body).toEqual({
-        results: expect.any(Array),
-        page: 1,
-        limit: 10,
-        totalPages: 1,
-        totalResults: 3,
-      });
-      expect(res.body.results).toHaveLength(3);
-      expect(res.body.results[0].id).toBe(admin._id.toHexString());
-      expect(res.body.results[1].id).toBe(userOne._id.toHexString());
-      expect(res.body.results[2].id).toBe(userTwo._id.toHexString());
-    });
-
-    test('should correctly sort the returned array if multiple sorting criteria are specified', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      const res = await request(app)
-        .get('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .query({ sortBy: 'role:desc,name:asc' })
-        .send()
-        .expect(httpStatus.OK);
-
-      expect(res.body).toEqual({
-        results: expect.any(Array),
-        page: 1,
-        limit: 10,
-        totalPages: 1,
-        totalResults: 3,
-      });
-      expect(res.body.results).toHaveLength(3);
-
-      const expectedOrder = [userOne, userTwo, admin].sort((a, b) => {
-        if (a.role < b.role) {
-          return 1;
-        }
-        if (a.role > b.role) {
-          return -1;
-        }
-        return a.name < b.name ? -1 : 1;
-      });
-
-      expectedOrder.forEach((user, index) => {
-        expect(res.body.results[index].id).toBe(user._id.toHexString());
-      });
-    });
-
-    test('should limit returned array if limit param is specified', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      const res = await request(app)
-        .get('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .query({ limit: 2 })
-        .send()
-        .expect(httpStatus.OK);
-
-      expect(res.body).toEqual({
-        results: expect.any(Array),
-        page: 1,
-        limit: 2,
-        totalPages: 2,
-        totalResults: 3,
-      });
-      expect(res.body.results).toHaveLength(2);
-      expect(res.body.results[0].id).toBe(userOne._id.toHexString());
-      expect(res.body.results[1].id).toBe(userTwo._id.toHexString());
-    });
-
-    test('should return the correct page if page and limit params are specified', async () => {
-      await insertUsers([userOne, userTwo, admin]);
-
-      const res = await request(app)
-        .get('/v1/users')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .query({ page: 2, limit: 2 })
-        .send()
-        .expect(httpStatus.OK);
-
-      expect(res.body).toEqual({
-        results: expect.any(Array),
-        page: 2,
-        limit: 2,
-        totalPages: 2,
-        totalResults: 3,
-      });
-      expect(res.body.results).toHaveLength(1);
-      expect(res.body.results[0].id).toBe(admin._id.toHexString());
-    });
-  });
-
-  describe('GET /v1/users/:userId', () => {
-    test('should return 200 and the user object if data is ok', async () => {
-      await insertUsers([userOne]);
-
-      const res = await request(app)
-        .get(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send()
-        .expect(httpStatus.OK);
-
-      expect(res.body).not.toHaveProperty('password');
-      expect(res.body).toEqual({
-        id: userOne._id.toHexString(),
-        email: userOne.email,
-        name: userOne.name,
-        role: userOne.role,
-        isEmailVerified: userOne.isEmailVerified,
-      });
-    });
-
-    test('should return 401 error if access token is missing', async () => {
-      await insertUsers([userOne]);
-
-      await request(app).get(`/v1/users/${userOne._id}`).send().expect(httpStatus.UNAUTHORIZED);
-    });
-
-    test('should return 403 error if user is trying to get another user', async () => {
-      await insertUsers([userOne, userTwo]);
-
-      await request(app)
-        .get(`/v1/users/${userTwo._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send()
-        .expect(httpStatus.FORBIDDEN);
-    });
-
-    test('should return 200 and the user object if admin is trying to get another user', async () => {
-      await insertUsers([userOne, admin]);
-
-      await request(app)
-        .get(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send()
-        .expect(httpStatus.OK);
-    });
-
-    test('should return 400 error if userId is not a valid mongo id', async () => {
-      await insertUsers([admin]);
-
-      await request(app)
-        .get('/v1/users/invalidId')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send()
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should return 404 error if user is not found', async () => {
-      await insertUsers([admin]);
-
-      await request(app)
-        .get(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send()
-        .expect(httpStatus.NOT_FOUND);
-    });
-  });
-
-  describe('DELETE /v1/users/:userId', () => {
-    test('should return 204 if data is ok', async () => {
-      await insertUsers([userOne]);
-
-      await request(app)
-        .delete(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send()
-        .expect(httpStatus.NO_CONTENT);
-
-      const dbUser = await User.findById(userOne._id);
-      expect(dbUser).toBeNull();
-    });
-
-    test('should return 401 error if access token is missing', async () => {
-      await insertUsers([userOne]);
-
-      await request(app).delete(`/v1/users/${userOne._id}`).send().expect(httpStatus.UNAUTHORIZED);
-    });
-
-    test('should return 403 error if user is trying to delete another user', async () => {
-      await insertUsers([userOne, userTwo]);
-
-      await request(app)
-        .delete(`/v1/users/${userTwo._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send()
-        .expect(httpStatus.FORBIDDEN);
-    });
-
-    test('should return 204 if admin is trying to delete another user', async () => {
-      await insertUsers([userOne, admin]);
-
-      await request(app)
-        .delete(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send()
-        .expect(httpStatus.NO_CONTENT);
-    });
-
-    test('should return 400 error if userId is not a valid mongo id', async () => {
-      await insertUsers([admin]);
-
-      await request(app)
-        .delete('/v1/users/invalidId')
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send()
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should return 404 error if user already is not found', async () => {
-      await insertUsers([admin]);
-
-      await request(app)
-        .delete(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send()
-        .expect(httpStatus.NOT_FOUND);
-    });
-  });
-
-  describe('PATCH /v1/users/:userId', () => {
-    test('should return 200 and successfully update user if data is ok', async () => {
-      await insertUsers([userOne]);
-      const updateBody = {
-        name: faker.name.findName(),
-        email: faker.internet.email().toLowerCase(),
-        password: 'newPassword1',
-      };
-
-      const res = await request(app)
-        .patch(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.OK);
-
-      expect(res.body).not.toHaveProperty('password');
-      expect(res.body).toEqual({
-        id: userOne._id.toHexString(),
-        name: updateBody.name,
-        email: updateBody.email,
-        role: 'user',
-        isEmailVerified: false,
-      });
-
-      const dbUser = await User.findById(userOne._id);
-      expect(dbUser).toBeDefined();
-      expect(dbUser.password).not.toBe(updateBody.password);
-      expect(dbUser).toMatchObject({ name: updateBody.name, email: updateBody.email, role: 'user' });
-    });
-
-    test('should return 401 error if access token is missing', async () => {
-      await insertUsers([userOne]);
-      const updateBody = { name: faker.name.findName() };
-
-      await request(app).patch(`/v1/users/${userOne._id}`).send(updateBody).expect(httpStatus.UNAUTHORIZED);
-    });
-
-    test('should return 403 if user is updating another user', async () => {
-      await insertUsers([userOne, userTwo]);
-      const updateBody = { name: faker.name.findName() };
-
-      await request(app)
-        .patch(`/v1/users/${userTwo._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.FORBIDDEN);
-    });
-
-    test('should return 200 and successfully update user if admin is updating another user', async () => {
-      await insertUsers([userOne, admin]);
-      const updateBody = { name: faker.name.findName() };
-
-      await request(app)
-        .patch(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.OK);
-    });
-
-    test('should return 404 if admin is updating another user that is not found', async () => {
-      await insertUsers([admin]);
-      const updateBody = { name: faker.name.findName() };
-
-      await request(app)
-        .patch(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.NOT_FOUND);
-    });
-
-    test('should return 400 error if userId is not a valid mongo id', async () => {
-      await insertUsers([admin]);
-      const updateBody = { name: faker.name.findName() };
-
-      await request(app)
-        .patch(`/v1/users/invalidId`)
-        .set('Authorization', `Bearer ${adminAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should return 400 if email is invalid', async () => {
-      await insertUsers([userOne]);
-      const updateBody = { email: 'invalidEmail' };
-
-      await request(app)
-        .patch(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should return 400 if email is already taken', async () => {
-      await insertUsers([userOne, userTwo]);
-      const updateBody = { email: userTwo.email };
-
-      await request(app)
-        .patch(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should not return 400 if email is my email', async () => {
-      await insertUsers([userOne]);
-      const updateBody = { email: userOne.email };
-
-      await request(app)
-        .patch(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.OK);
-    });
-
-    test('should return 400 if password length is less than 8 characters', async () => {
-      await insertUsers([userOne]);
-      const updateBody = { password: 'passwo1' };
-
-      await request(app)
-        .patch(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.BAD_REQUEST);
-    });
-
-    test('should return 400 if password does not contain both letters and numbers', async () => {
-      await insertUsers([userOne]);
-      const updateBody = { password: 'password' };
-
-      await request(app)
-        .patch(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.BAD_REQUEST);
-
-      updateBody.password = '11111111';
-
-      await request(app)
-        .patch(`/v1/users/${userOne._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.BAD_REQUEST);
-    });
   });
 });
+
+// describe('User routes', () => {
+//   describe('POST /v1/users', () => {
+//     let newUser;
+
+//     beforeEach(() => {
+//       newUser = {
+//         name: faker.name.findName(),
+//         email: faker.internet.email().toLowerCase(),
+//         password: 'password1',
+//         role: 'user',
+//       };
+//     });
+
+//     test('should return 201 and successfully create new user if data is ok', async () => {
+//       await insertUsers([admin]);
+
+//       const res = await request(app)
+//         .post('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(newUser)
+//         .expect(httpStatus.CREATED);
+
+//       expect(res.body).not.toHaveProperty('password');
+//       expect(res.body).toEqual({
+//         id: expect.anything(),
+//         name: newUser.name,
+//         email: newUser.email,
+//         role: newUser.role,
+//         isEmailVerified: false,
+//       });
+
+//       const dbUser = await User.findById(res.body.id);
+//       expect(dbUser).toBeDefined();
+//       expect(dbUser.password).not.toBe(newUser.password);
+//       expect(dbUser).toMatchObject({ name: newUser.name, email: newUser.email, role: newUser.role, isEmailVerified: false });
+//     });
+
+//     test('should be able to create an admin as well', async () => {
+//       await insertUsers([admin]);
+//       newUser.role = 'admin';
+
+//       const res = await request(app)
+//         .post('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(newUser)
+//         .expect(httpStatus.CREATED);
+
+//       expect(res.body.role).toBe('admin');
+
+//       const dbUser = await User.findById(res.body.id);
+//       expect(dbUser.role).toBe('admin');
+//     });
+
+//     test('should return 401 error if access token is missing', async () => {
+//       await request(app).post('/v1/users').send(newUser).expect(httpStatus.UNAUTHORIZED);
+//     });
+
+//     test('should return 403 error if logged in user is not admin', async () => {
+//       await insertUsers([userOne]);
+
+//       await request(app)
+//         .post('/v1/users')
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send(newUser)
+//         .expect(httpStatus.FORBIDDEN);
+//     });
+
+//     test('should return 400 error if email is invalid', async () => {
+//       await insertUsers([admin]);
+//       newUser.email = 'invalidEmail';
+
+//       await request(app)
+//         .post('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(newUser)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should return 400 error if email is already used', async () => {
+//       await insertUsers([admin, userOne]);
+//       newUser.email = userOne.email;
+
+//       await request(app)
+//         .post('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(newUser)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should return 400 error if password length is less than 8 characters', async () => {
+//       await insertUsers([admin]);
+//       newUser.password = 'passwo1';
+
+//       await request(app)
+//         .post('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(newUser)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should return 400 error if password does not contain both letters and numbers', async () => {
+//       await insertUsers([admin]);
+//       newUser.password = 'password';
+
+//       await request(app)
+//         .post('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(newUser)
+//         .expect(httpStatus.BAD_REQUEST);
+
+//       newUser.password = '1111111';
+
+//       await request(app)
+//         .post('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(newUser)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should return 400 error if role is neither user nor admin', async () => {
+//       await insertUsers([admin]);
+//       newUser.role = 'invalid';
+
+//       await request(app)
+//         .post('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(newUser)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+//   });
+
+//   describe('GET /v1/users', () => {
+//     test('should return 200 and apply the default query options', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       const res = await request(app)
+//         .get('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send()
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).toEqual({
+//         results: expect.any(Array),
+//         page: 1,
+//         limit: 10,
+//         totalPages: 1,
+//         totalResults: 3,
+//       });
+//       expect(res.body.results).toHaveLength(3);
+//       expect(res.body.results[0]).toEqual({
+//         id: userOne._id.toHexString(),
+//         name: userOne.name,
+//         email: userOne.email,
+//         role: userOne.role,
+//         isEmailVerified: userOne.isEmailVerified,
+//       });
+//     });
+
+//     test('should return 401 if access token is missing', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       await request(app).get('/v1/users').send().expect(httpStatus.UNAUTHORIZED);
+//     });
+
+//     test('should return 403 if a non-admin is trying to access all users', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       await request(app)
+//         .get('/v1/users')
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send()
+//         .expect(httpStatus.FORBIDDEN);
+//     });
+
+//     test('should correctly apply filter on name field', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       const res = await request(app)
+//         .get('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .query({ name: userOne.name })
+//         .send()
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).toEqual({
+//         results: expect.any(Array),
+//         page: 1,
+//         limit: 10,
+//         totalPages: 1,
+//         totalResults: 1,
+//       });
+//       expect(res.body.results).toHaveLength(1);
+//       expect(res.body.results[0].id).toBe(userOne._id.toHexString());
+//     });
+
+//     test('should correctly apply filter on role field', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       const res = await request(app)
+//         .get('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .query({ role: 'user' })
+//         .send()
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).toEqual({
+//         results: expect.any(Array),
+//         page: 1,
+//         limit: 10,
+//         totalPages: 1,
+//         totalResults: 2,
+//       });
+//       expect(res.body.results).toHaveLength(2);
+//       expect(res.body.results[0].id).toBe(userOne._id.toHexString());
+//       expect(res.body.results[1].id).toBe(userTwo._id.toHexString());
+//     });
+
+//     test('should correctly sort the returned array if descending sort param is specified', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       const res = await request(app)
+//         .get('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .query({ sortBy: 'role:desc' })
+//         .send()
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).toEqual({
+//         results: expect.any(Array),
+//         page: 1,
+//         limit: 10,
+//         totalPages: 1,
+//         totalResults: 3,
+//       });
+//       expect(res.body.results).toHaveLength(3);
+//       expect(res.body.results[0].id).toBe(userOne._id.toHexString());
+//       expect(res.body.results[1].id).toBe(userTwo._id.toHexString());
+//       expect(res.body.results[2].id).toBe(admin._id.toHexString());
+//     });
+
+//     test('should correctly sort the returned array if ascending sort param is specified', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       const res = await request(app)
+//         .get('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .query({ sortBy: 'role:asc' })
+//         .send()
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).toEqual({
+//         results: expect.any(Array),
+//         page: 1,
+//         limit: 10,
+//         totalPages: 1,
+//         totalResults: 3,
+//       });
+//       expect(res.body.results).toHaveLength(3);
+//       expect(res.body.results[0].id).toBe(admin._id.toHexString());
+//       expect(res.body.results[1].id).toBe(userOne._id.toHexString());
+//       expect(res.body.results[2].id).toBe(userTwo._id.toHexString());
+//     });
+
+//     test('should correctly sort the returned array if multiple sorting criteria are specified', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       const res = await request(app)
+//         .get('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .query({ sortBy: 'role:desc,name:asc' })
+//         .send()
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).toEqual({
+//         results: expect.any(Array),
+//         page: 1,
+//         limit: 10,
+//         totalPages: 1,
+//         totalResults: 3,
+//       });
+//       expect(res.body.results).toHaveLength(3);
+
+//       const expectedOrder = [userOne, userTwo, admin].sort((a, b) => {
+//         if (a.role < b.role) {
+//           return 1;
+//         }
+//         if (a.role > b.role) {
+//           return -1;
+//         }
+//         return a.name < b.name ? -1 : 1;
+//       });
+
+//       expectedOrder.forEach((user, index) => {
+//         expect(res.body.results[index].id).toBe(user._id.toHexString());
+//       });
+//     });
+
+//     test('should limit returned array if limit param is specified', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       const res = await request(app)
+//         .get('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .query({ limit: 2 })
+//         .send()
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).toEqual({
+//         results: expect.any(Array),
+//         page: 1,
+//         limit: 2,
+//         totalPages: 2,
+//         totalResults: 3,
+//       });
+//       expect(res.body.results).toHaveLength(2);
+//       expect(res.body.results[0].id).toBe(userOne._id.toHexString());
+//       expect(res.body.results[1].id).toBe(userTwo._id.toHexString());
+//     });
+
+//     test('should return the correct page if page and limit params are specified', async () => {
+//       await insertUsers([userOne, userTwo, admin]);
+
+//       const res = await request(app)
+//         .get('/v1/users')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .query({ page: 2, limit: 2 })
+//         .send()
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).toEqual({
+//         results: expect.any(Array),
+//         page: 2,
+//         limit: 2,
+//         totalPages: 2,
+//         totalResults: 3,
+//       });
+//       expect(res.body.results).toHaveLength(1);
+//       expect(res.body.results[0].id).toBe(admin._id.toHexString());
+//     });
+//   });
+
+//   describe('GET /v1/users/:userId', () => {
+//     test('should return 200 and the user object if data is ok', async () => {
+//       await insertUsers([userOne]);
+
+//       const res = await request(app)
+//         .get(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send()
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).not.toHaveProperty('password');
+//       expect(res.body).toEqual({
+//         id: userOne._id.toHexString(),
+//         email: userOne.email,
+//         name: userOne.name,
+//         role: userOne.role,
+//         isEmailVerified: userOne.isEmailVerified,
+//       });
+//     });
+
+//     test('should return 401 error if access token is missing', async () => {
+//       await insertUsers([userOne]);
+
+//       await request(app).get(`/v1/users/${userOne._id}`).send().expect(httpStatus.UNAUTHORIZED);
+//     });
+
+//     test('should return 403 error if user is trying to get another user', async () => {
+//       await insertUsers([userOne, userTwo]);
+
+//       await request(app)
+//         .get(`/v1/users/${userTwo._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send()
+//         .expect(httpStatus.FORBIDDEN);
+//     });
+
+//     test('should return 200 and the user object if admin is trying to get another user', async () => {
+//       await insertUsers([userOne, admin]);
+
+//       await request(app)
+//         .get(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send()
+//         .expect(httpStatus.OK);
+//     });
+
+//     test('should return 400 error if userId is not a valid mongo id', async () => {
+//       await insertUsers([admin]);
+
+//       await request(app)
+//         .get('/v1/users/invalidId')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send()
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should return 404 error if user is not found', async () => {
+//       await insertUsers([admin]);
+
+//       await request(app)
+//         .get(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send()
+//         .expect(httpStatus.NOT_FOUND);
+//     });
+//   });
+
+//   describe('DELETE /v1/users/:userId', () => {
+//     test('should return 204 if data is ok', async () => {
+//       await insertUsers([userOne]);
+
+//       await request(app)
+//         .delete(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send()
+//         .expect(httpStatus.NO_CONTENT);
+
+//       const dbUser = await User.findById(userOne._id);
+//       expect(dbUser).toBeNull();
+//     });
+
+//     test('should return 401 error if access token is missing', async () => {
+//       await insertUsers([userOne]);
+
+//       await request(app).delete(`/v1/users/${userOne._id}`).send().expect(httpStatus.UNAUTHORIZED);
+//     });
+
+//     test('should return 403 error if user is trying to delete another user', async () => {
+//       await insertUsers([userOne, userTwo]);
+
+//       await request(app)
+//         .delete(`/v1/users/${userTwo._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send()
+//         .expect(httpStatus.FORBIDDEN);
+//     });
+
+//     test('should return 204 if admin is trying to delete another user', async () => {
+//       await insertUsers([userOne, admin]);
+
+//       await request(app)
+//         .delete(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send()
+//         .expect(httpStatus.NO_CONTENT);
+//     });
+
+//     test('should return 400 error if userId is not a valid mongo id', async () => {
+//       await insertUsers([admin]);
+
+//       await request(app)
+//         .delete('/v1/users/invalidId')
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send()
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should return 404 error if user already is not found', async () => {
+//       await insertUsers([admin]);
+
+//       await request(app)
+//         .delete(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send()
+//         .expect(httpStatus.NOT_FOUND);
+//     });
+//   });
+
+//   describe('PATCH /v1/users/:userId', () => {
+//     test('should return 200 and successfully update user if data is ok', async () => {
+//       await insertUsers([userOne]);
+//       const updateBody = {
+//         name: faker.name.findName(),
+//         email: faker.internet.email().toLowerCase(),
+//         password: 'newPassword1',
+//       };
+
+//       const res = await request(app)
+//         .patch(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.OK);
+
+//       expect(res.body).not.toHaveProperty('password');
+//       expect(res.body).toEqual({
+//         id: userOne._id.toHexString(),
+//         name: updateBody.name,
+//         email: updateBody.email,
+//         role: 'user',
+//         isEmailVerified: false,
+//       });
+
+//       const dbUser = await User.findById(userOne._id);
+//       expect(dbUser).toBeDefined();
+//       expect(dbUser.password).not.toBe(updateBody.password);
+//       expect(dbUser).toMatchObject({ name: updateBody.name, email: updateBody.email, role: 'user' });
+//     });
+
+//     test('should return 401 error if access token is missing', async () => {
+//       await insertUsers([userOne]);
+//       const updateBody = { name: faker.name.findName() };
+
+//       await request(app).patch(`/v1/users/${userOne._id}`).send(updateBody).expect(httpStatus.UNAUTHORIZED);
+//     });
+
+//     test('should return 403 if user is updating another user', async () => {
+//       await insertUsers([userOne, userTwo]);
+//       const updateBody = { name: faker.name.findName() };
+
+//       await request(app)
+//         .patch(`/v1/users/${userTwo._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.FORBIDDEN);
+//     });
+
+//     test('should return 200 and successfully update user if admin is updating another user', async () => {
+//       await insertUsers([userOne, admin]);
+//       const updateBody = { name: faker.name.findName() };
+
+//       await request(app)
+//         .patch(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.OK);
+//     });
+
+//     test('should return 404 if admin is updating another user that is not found', async () => {
+//       await insertUsers([admin]);
+//       const updateBody = { name: faker.name.findName() };
+
+//       await request(app)
+//         .patch(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.NOT_FOUND);
+//     });
+
+//     test('should return 400 error if userId is not a valid mongo id', async () => {
+//       await insertUsers([admin]);
+//       const updateBody = { name: faker.name.findName() };
+
+//       await request(app)
+//         .patch(`/v1/users/invalidId`)
+//         .set('Authorization', `Bearer ${adminAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should return 400 if email is invalid', async () => {
+//       await insertUsers([userOne]);
+//       const updateBody = { email: 'invalidEmail' };
+
+//       await request(app)
+//         .patch(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should return 400 if email is already taken', async () => {
+//       await insertUsers([userOne, userTwo]);
+//       const updateBody = { email: userTwo.email };
+
+//       await request(app)
+//         .patch(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should not return 400 if email is my email', async () => {
+//       await insertUsers([userOne]);
+//       const updateBody = { email: userOne.email };
+
+//       await request(app)
+//         .patch(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.OK);
+//     });
+
+//     test('should return 400 if password length is less than 8 characters', async () => {
+//       await insertUsers([userOne]);
+//       const updateBody = { password: 'passwo1' };
+
+//       await request(app)
+//         .patch(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+
+//     test('should return 400 if password does not contain both letters and numbers', async () => {
+//       await insertUsers([userOne]);
+//       const updateBody = { password: 'password' };
+
+//       await request(app)
+//         .patch(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.BAD_REQUEST);
+
+//       updateBody.password = '11111111';
+
+//       await request(app)
+//         .patch(`/v1/users/${userOne._id}`)
+//         .set('Authorization', `Bearer ${userOneAccessToken}`)
+//         .send(updateBody)
+//         .expect(httpStatus.BAD_REQUEST);
+//     });
+//   });
+// });


### PR DESCRIPTION
- When a message is created using POST `/messages/`, the current active pseudonym for the user is determined and saved with the message in the db
- GET `/messages` now returns pseudonym (and upVotes/downVotes) for messages, for display on front-end.