### PR TITLE
Add additional options for channel creation

### DIFF
--- a/src/controllers/topic.controller.js
+++ b/src/controllers/topic.controller.js
@@ -1,6 +1,7 @@
 const httpStatus = require('http-status');
 const catchAsync = require('../utils/catchAsync');
 const { topicService, userService } = require('../services');
+const ApiError = require('../utils/ApiError');
 
 const createTopic = catchAsync(async (req, res) => {
   const topic = await topicService.createTopic(req.body, req.user);
@@ -31,10 +32,19 @@ const publicTopics = catchAsync(async (req, res) => {
   res.status(httpStatus.OK).send(topics.slice(0,10));
 });
 
+const authenticate = catchAsync(async (req, res) => {
+  const result = await topicService.verifyPasscode(req.body.topicId, req.body.passcode);
+  if (!result) {
+    throw new ApiError(httpStatus.UNAUTHORIZED, 'Invalid passcode');
+  }
+  res.status(httpStatus.OK).send();
+});
+
 module.exports = {
   createTopic,
   userTopics,
   getTopic,
   allTopics,
   publicTopics,
+  authenticate,
 };

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -69,6 +69,42 @@ components:
         message:
           type: string
 
+    Topic:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+          required: true
+        slug:
+          type: string
+        votingAllowed:
+          type: boolean
+        private:
+          type: boolean
+          required: true
+        archivable:
+          type: boolean
+          required: true
+        archived:
+          type: boolean
+        owner:
+          type
+        createdAt:
+          type: date
+        updatedAt:
+          type: date
+      example:
+        id: 61b7ea6aa771004e80ed4409
+        name: favorite dogs
+        slug: favorite-dogs
+        votingAllowed: true
+        private: false
+        archivable: true
+        createdAt: 2021-11-30T01:51:01.639Z
+        updatedAt: 2021-11-30T01:51:01.639Z
+
   responses:
     DuplicateEmail:
       description: Email already taken

--- a/src/models/topic.model.js
+++ b/src/models/topic.model.js
@@ -24,6 +24,7 @@ const topicSchema = mongoose.Schema(
     },
     passcode: {
       type: Number,
+      private: true,
     },
     archivable: {
       type: Boolean,

--- a/src/models/topic.model.js
+++ b/src/models/topic.model.js
@@ -14,6 +14,21 @@ const topicSchema = mongoose.Schema(
       required: true,
       trim: true,
     },
+    voting: {
+      type: Boolean,
+      required: true,
+    },
+    private: {
+      type: Boolean,
+      required: true,
+    },
+    archive: {
+      type: Boolean,
+      required: true,
+    },
+    passcode: {
+      type: Number,
+    },
     owner: {
       type: mongoose.SchemaTypes.ObjectId,
       ref: 'User',

--- a/src/models/topic.model.js
+++ b/src/models/topic.model.js
@@ -14,7 +14,7 @@ const topicSchema = mongoose.Schema(
       required: true,
       trim: true,
     },
-    voting: {
+    votingAllowed: {
       type: Boolean,
       required: true,
     },
@@ -22,12 +22,15 @@ const topicSchema = mongoose.Schema(
       type: Boolean,
       required: true,
     },
-    archive: {
+    passcode: {
+      type: Number,
+    },
+    archivable: {
       type: Boolean,
       required: true,
     },
-    passcode: {
-      type: Number,
+    archived: {
+      type: Boolean,
     },
     owner: {
       type: mongoose.SchemaTypes.ObjectId,

--- a/src/routes/v1/topics.route.js
+++ b/src/routes/v1/topics.route.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const topicController = require('../../controllers/topic.controller');
 const auth = require('../../middlewares/auth');
+const validate = require('../../middlewares/validate');
+const topicValidation = require('../../validations/topic.validation');
 
 const router = express.Router();
 
-router.route('/').post(auth('createTopic'), topicController.createTopic);
+router.route('/').post(auth('createTopic'), validate(topicValidation.createTopic), topicController.createTopic);
 
 /**
  * @swagger
@@ -102,5 +104,7 @@ router.route('/public/:token').get(topicController.publicTopics);
  */
 router.route('/').get(auth('allTopics'), topicController.allTopics);
 router.route('/:topicId').get(topicController.getTopic);
+
+router.route('/auth').post(validate(topicValidation.authenticate), topicController.authenticate);
 
 module.exports = router;

--- a/src/routes/v1/topics.route.js
+++ b/src/routes/v1/topics.route.js
@@ -6,14 +6,47 @@ const topicValidation = require('../../validations/topic.validation');
 
 const router = express.Router();
 
-router.route('/').post(auth('createTopic'), validate(topicValidation.createTopic), topicController.createTopic);
-
 /**
  * @swagger
  * tags:
  *   name: Topic
  *   description: Manage application Topics
  */
+
+/**
+ * @swagger
+ * /topics:
+ *   post:
+ *     description: Create a topic
+ *     tags: [Topic]
+ *     produces:
+ *       - application/json
+ *     requestBody:
+ *       required: true
+ *       content: 
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               votingAllowed:
+ *                 type: boolean
+ *               private:
+ *                 type: boolean
+ *               archivable:
+ *                 type: boolean
+ *     responses:
+ *       200:
+ *         description: ok
+*         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               $ref: '#/components/schemas/Topic'
+ *                      
+ */
+router.route('/').post(auth('createTopic'), validate(topicValidation.createTopic), topicController.createTopic);
 
 /**
  * @swagger
@@ -105,6 +138,30 @@ router.route('/public/:token').get(topicController.publicTopics);
 router.route('/').get(auth('allTopics'), topicController.allTopics);
 router.route('/:topicId').get(topicController.getTopic);
 
+/**
+ * @swagger
+ * /topics/auth:
+ *   post:
+ *     description: Verify a private topic passcode
+ *     tags: [Topic]
+ *     produces:
+ *       - application/json
+ *     requestBody:
+ *       required: true
+ *       content: 
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               topicId:
+ *                 type: string
+ *               passcode:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: ok
+ *                      
+ */
 router.route('/auth').post(validate(topicValidation.authenticate), topicController.authenticate);
 
 module.exports = router;

--- a/src/services/topic.service.js
+++ b/src/services/topic.service.js
@@ -23,9 +23,9 @@ const createTopic = async (topicBody, user) => {
   }
   const topic = await Topic.create({
     name: topicBody.name,
-    voting: topicBody.voting,
+    votingAllowed: topicBody.votingAllowed,
     private: topicBody.private,
-    archive: topicBody.archive,
+    archivable: topicBody.archivable,
     passcode,
     owner: user,
   });

--- a/src/services/topic.service.js
+++ b/src/services/topic.service.js
@@ -1,4 +1,5 @@
 const { Topic } = require('../models');
+const crypto = require('crypto');
 
 /**
  * Create a topic
@@ -6,8 +7,26 @@ const { Topic } = require('../models');
  * @returns {Promise<Topic>}
  */
 const createTopic = async (topicBody, user) => {
+  const randomPasscode = async (min, max) => {
+    return new Promise((resolve, reject) => {
+      crypto.randomInt(min,max, (err, res) => {
+        if (err)
+          reject(err);
+        resolve(res);
+      });
+    });
+  };
+  
+  let passcode = null;
+  if (topicBody.private) {
+    passcode = await randomPasscode(1000000,9999999);
+  }
   const topic = await Topic.create({
     name: topicBody.name,
+    voting: topicBody.voting,
+    private: topicBody.private,
+    archive: topicBody.archive,
+    passcode,
     owner: user,
   });
   return topic;
@@ -26,6 +45,13 @@ const allTopics = async () => {
 const findById = async (id) => {
   const topic = await Topic.findOne({ _id: id }).select('name slug').exec();
   return topic;
+};
+
+const verifyPasscode = async (topicId, passcode) => {
+  const topic = await Topic.findById(topicId);
+  console.log('passcode', passcode);
+  console.log('topic.passcode', topic.passcode);
+  return passcode === topic.passcode;
 };
 
 const topicsWithSortData = async(topicQuery) => {
@@ -93,4 +119,5 @@ module.exports = {
   userTopics,
   findById,
   allTopics,
+  verifyPasscode,
 };

--- a/src/services/topic.service.js
+++ b/src/services/topic.service.js
@@ -49,8 +49,6 @@ const findById = async (id) => {
 
 const verifyPasscode = async (topicId, passcode) => {
   const topic = await Topic.findById(topicId);
-  console.log('passcode', passcode);
-  console.log('topic.passcode', topic.passcode);
   return passcode === topic.passcode;
 };
 

--- a/src/validations/topic.validation.js
+++ b/src/validations/topic.validation.js
@@ -3,9 +3,9 @@ const Joi = require('joi');
 const createTopic = {
   body: Joi.object().keys({
     name: Joi.string().required(),
-    voting: Joi.boolean().required(),
+    votingAllowed: Joi.boolean().required(),
     private: Joi.boolean().required(),
-    archive: Joi.boolean().required(),
+    archivable: Joi.boolean().required(),
   }),
 };
 

--- a/src/validations/topic.validation.js
+++ b/src/validations/topic.validation.js
@@ -1,0 +1,22 @@
+const Joi = require('joi');
+
+const createTopic = {
+  body: Joi.object().keys({
+    name: Joi.string().required(),
+    voting: Joi.boolean().required(),
+    private: Joi.boolean().required(),
+    archive: Joi.boolean().required(),
+  }),
+};
+
+const authenticate = {
+  body: Joi.object().keys({
+    passcode: Joi.number().required(),
+    topicId: Joi.string().required(),
+  }),
+};
+
+module.exports = {
+  authenticate,
+  createTopic,
+};

--- a/tests/fixtures/message.fixture.js
+++ b/tests/fixtures/message.fixture.js
@@ -11,7 +11,7 @@ const messageOne = {
     owner: registeredUser._id,
 };
 
-const messageTwo = {
+const messagePost = {
     body: faker.lorem.words(10),
     thread: threadOne._id,
 };
@@ -22,6 +22,6 @@ const insertMessages = async (msgs) => {
 
 module.exports = {
   messageOne,
-  messageTwo,
+  messagePost,
   insertMessages,
 };

--- a/tests/fixtures/thread.fixture.js
+++ b/tests/fixtures/thread.fixture.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const faker = require('faker');
 const Thread = require('../../src/models/thread.model');
 const { userOne } = require('./user.fixture');
-const { topicOne } = require('./topic.fixture');
+const { publicTopic } = require('./topic.fixture');
 
 
 const nameSlug = faker.lorem.word().toLowerCase();
@@ -12,7 +12,7 @@ const threadOne = {
     name: nameSlug,
     slug: nameSlug,
     owner: userOne._id,
-    topic: topicOne._id,
+    topic: publicTopic._id,
 };
 
 const insertThreads = async (threads) => {

--- a/tests/fixtures/topic.fixture.js
+++ b/tests/fixtures/topic.fixture.js
@@ -4,12 +4,40 @@ const Topic = require('../../src/models/topic.model');
 const { userOne } = require('./user.fixture');
 
 const nameSlug = faker.lorem.word().toLowerCase();
+const getRandomInt = (min, max) => {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min) + min);
+}
 
-const topicOne = {
+const topicPost = {
+  name: nameSlug,
+  votingAllowed: true,
+  private: false,
+  archivable: true,
+};
+
+const publicTopic = {
     _id: mongoose.Types.ObjectId(),
     name: nameSlug,
     slug: nameSlug,
+    votingAllowed: true,
+    private: false,
+    archivable: true,
+    archived: false,
     owner: userOne._id,
+};
+
+const privateTopic = {
+  _id: mongoose.Types.ObjectId(),
+  name: nameSlug,
+  slug: nameSlug,
+  votingAllowed: false,
+  private: true,
+  passcode: getRandomInt(1000000, 9999999),
+  archivable: true,
+  archived: false,
+  owner: userOne._id,
 };
 
 const insertTopics = async (topics) => {
@@ -17,6 +45,9 @@ const insertTopics = async (topics) => {
 };
 
 module.exports = {
-  topicOne,
+  publicTopic,
+  privateTopic,
+  topicPost,
   insertTopics,
+  getRandomInt,
 };

--- a/tests/integration/message.test.js
+++ b/tests/integration/message.test.js
@@ -1,12 +1,12 @@
 const setupTestDB = require('../utils/setupTestDB');
-const { messageOne, insertMessages, messageTwo } = require('../fixtures/message.fixture');
+const { messageOne, insertMessages, messagePost } = require('../fixtures/message.fixture');
 const app = require('../../src/app');
 const request = require('supertest');
 const { insertUsers, registeredUser } = require('../fixtures/user.fixture');
 const { registeredUserAccessToken } = require('../fixtures/token.fixture');
 const httpStatus = require('http-status');
 const Message = require('../../src/models/message.model');
-const { insertTopics, topicOne } = require('../fixtures/topic.fixture');
+const { insertTopics, publicTopic } = require('../fixtures/topic.fixture');
 const { threadOne, insertThreads } = require('../fixtures/thread.fixture');
 
 setupTestDB();
@@ -49,12 +49,12 @@ describe('Message routes', () => {
     describe('POST /v1/messages', () => {
         test('should return 201 and create message', async () => {
             await insertUsers([registeredUser]);
-            await insertTopics([topicOne]);
+            await insertTopics([publicTopic]);
             await insertThreads([threadOne]);
             const res =  await request(app)
                 .post(`/v1/messages/`)
                 .set('Authorization', `Bearer ${registeredUserAccessToken}`)
-                .send(messageTwo)
+                .send(messagePost)
                 .expect(httpStatus.CREATED);
 
             const msgs = await Message.find({ id: res.id });
@@ -63,12 +63,12 @@ describe('Message routes', () => {
 
         test('should create message, and message should have current active pseudonym', async () => {
             const userRet = await insertUsers([registeredUser]);
-            await insertTopics([topicOne]);
+            await insertTopics([publicTopic]);
             await insertThreads([threadOne]);
             const res =  await request(app)
                 .post(`/v1/messages/`)
                 .set('Authorization', `Bearer ${registeredUserAccessToken}`)
-                .send(messageTwo)
+                .send(messagePost)
                 .expect(httpStatus.CREATED);
 
             const msgs = await Message.find({ id: res.id });

--- a/tests/integration/topic.test.js
+++ b/tests/integration/topic.test.js
@@ -1,0 +1,64 @@
+const setupTestDB = require('../utils/setupTestDB');
+const app = require('../../src/app');
+const request = require('supertest');
+const { insertUsers, registeredUser } = require('../fixtures/user.fixture');
+const { registeredUserAccessToken } = require('../fixtures/token.fixture');
+const httpStatus = require('http-status');
+const { topicPost, privateTopic, insertTopics, getRandomInt } = require('../fixtures/topic.fixture');
+const faker = require('faker');
+
+setupTestDB();
+
+describe('Topic routes', () => {
+    describe('POST /v1/topics/', () => {
+        test('should return 201 and create a topic', async () => {
+            await insertUsers([registeredUser]);
+            await request(app)
+                .post(`/v1/topics`)
+                .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+                .send(topicPost)
+                .expect(httpStatus.CREATED);
+        });
+
+        test('should return 400 if missing a required field', async () => {
+            await insertUsers([registeredUser]);
+            const badPost = topicPost;
+            badPost.private = undefined;
+            await request(app)
+                .post(`/v1/topics`)
+                .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+                .send(topicPost)
+                .expect(httpStatus.BAD_REQUEST);
+        });
+    });
+
+    describe('POST /v1/topics/auth', () => {
+        test('should return 200 if passcode is correct', async () => {
+            await insertUsers([registeredUser]);
+            await insertTopics([privateTopic]);
+            await request(app)
+                .post(`/v1/topics/auth`)
+                .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+                .send({
+                    topicId: privateTopic._id,
+                    passcode: privateTopic.passcode
+                })
+                .expect(httpStatus.OK);
+        });
+
+        test('should return 401 if passcode is invalid', async () => {
+            await insertUsers([registeredUser]);
+            await insertTopics([privateTopic]);
+            // Note: once in a blue moon, this could produce a false positive
+            const badPasscode = getRandomInt(1000000, 9999999);
+            await request(app)
+                .post(`/v1/topics/auth`)
+                .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+                .send({
+                    topicId: privateTopic._id,
+                    passcode: badPasscode
+                })
+                .expect(httpStatus.UNAUTHORIZED);
+        });
+    });
+});


### PR DESCRIPTION
- Updated `/topics` POST endpoint to accept new fields: votingAllowed, private, and archivable
- Generated 7 digit passcode if new topic is created that is set to private
- Added new `/topics/auth` endpoint for verification of private channel passcodes
- Added Swagger docs and tests for the above changes