### PR TITLE
Add support for channel auto delete and archiving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6822,6 +6822,14 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-cron": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.0.tgz",
+      "integrity": "sha512-DDwIvvuCwrNiaU7HEivFDULcaQualDv7KoNlB/UU1wPW0n1tDEmBJKhEIE6DlF2FuoOHcNbLJ8ITL2Iv/3AWmA==",
+      "requires": {
+        "moment-timezone": "^0.5.31"
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "moment": "^2.24.0",
     "mongoose": "^5.7.7",
     "morgan": "^1.9.1",
+    "node-cron": "^3.0.0",
     "nodemailer": "^6.3.1",
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",

--- a/src/config/tokens.js
+++ b/src/config/tokens.js
@@ -3,6 +3,7 @@ const tokenTypes = {
   REFRESH: 'refresh',
   RESET_PASSWORD: 'resetPassword',
   VERIFY_EMAIL: 'verifyEmail',
+  ARCHIVE_TOPIC: 'archiveTopic',
 };
 
 module.exports = {

--- a/src/controllers/topic.controller.js
+++ b/src/controllers/topic.controller.js
@@ -2,6 +2,7 @@ const httpStatus = require('http-status');
 const catchAsync = require('../utils/catchAsync');
 const { topicService, userService, tokenService } = require('../services');
 const ApiError = require('../utils/ApiError');
+const { tokenTypes } = require('../config/tokens');
 
 const createTopic = catchAsync(async (req, res) => {
   const topic = await topicService.createTopic(req.body, req.user);
@@ -41,7 +42,7 @@ const authenticate = catchAsync(async (req, res) => {
 });
 
 const archiveTopic = catchAsync(async (req, res) => {
-  await tokenService.verifyToken(req.body.token);
+  await tokenService.verifyToken(req.body.token, tokenTypes.ARCHIVE_TOPIC);
   await topicService.archiveTopic(req.body.topicId);
   res.status(httpStatus.OK).send();
 });

--- a/src/controllers/topic.controller.js
+++ b/src/controllers/topic.controller.js
@@ -1,6 +1,6 @@
 const httpStatus = require('http-status');
 const catchAsync = require('../utils/catchAsync');
-const { topicService, userService } = require('../services');
+const { topicService, userService, tokenService } = require('../services');
 const ApiError = require('../utils/ApiError');
 
 const createTopic = catchAsync(async (req, res) => {
@@ -40,6 +40,12 @@ const authenticate = catchAsync(async (req, res) => {
   res.status(httpStatus.OK).send();
 });
 
+const archiveTopic = catchAsync(async (req, res) => {
+  await tokenService.verifyToken(req.body.token);
+  await topicService.archiveTopic(req.body.topicId);
+  res.status(httpStatus.OK).send();
+});
+
 module.exports = {
   createTopic,
   userTopics,
@@ -47,4 +53,5 @@ module.exports = {
   allTopics,
   publicTopics,
   authenticate,
+  archiveTopic,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const app = require('./app');
 const config = require('./config/config');
 const logger = require('./config/logger');
+const { startJobs } = require('./jobs');
 
 let server;
 mongoose.connect(config.mongoose.url, config.mongoose.options).then(() => {
@@ -9,6 +10,8 @@ mongoose.connect(config.mongoose.url, config.mongoose.options).then(() => {
   server = app.listen(config.port, () => {
     logger.info(`Listening to port ${config.port}`);
   });
+  if (config.env !== 'test')
+    startJobs();
 });
 
 const exitHandler = () => {

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -4,7 +4,7 @@ const logger = require('./config/logger');
 
 const startJobs = () => {
     logger.info('Started nodecron jobs that run once per day at 1am UTC');
-    cron.schedule('* * * * *', async () => {
+    cron.schedule('0 1 * * *', async () => {
         try {
             // Delete old topics job
             logger.info(`Started delete old topics job.`);

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -3,13 +3,30 @@ const { topicService } = require('../src/services');
 const logger = require('./config/logger');
 
 const startJobs = () => {
+    logger.info('Started nodecron jobs that run once per day at 1am UTC');
     cron.schedule('* * * * *', async () => {
-        logger.info('Starting deleteOldTopics job');
         try {
-            const result = await topicService.deleteOldTopics();
-            logger.info(`Successfully deleted ${result.deletedCount} old topics.`);
+            // Delete old topics job
+            logger.info(`Started delete old topics job.`);
+            const deleteResult = await topicService.deleteOldTopics();
+            if (deleteResult.length > 0) {
+                logger.info(`Successfully deleted ${deleteResult.length} old topics. Topic ids: ${deleteResult.map(x => x._id).join()}`);
+            } else {
+                logger.info(`Did not find any old topics to delete.`);
+            }
+            logger.info(`Ended delete old topics job.`);
+
+            // Archive topics job
+            logger.info(`Started email users to archive job.`);
+            const emailResult = await topicService.emailUsersToArchive();
+            if (emailResult.length > 0) {
+                logger.info(`Successfully deleted ${emailResult.length} old topics. Topic ids: ${emailResult.map(x => x._id).join()}`);
+            } else {
+                logger.info(`Did not find any users to notify for archiving.`);
+            }
+            logger.info(`Ended email users to archive job.`);
         } catch (err) {
-            logger.error('Error occurred in deleteOldTopics job: ', err);
+            logger.error('Error occurred in nodecron jobs: ', err);
         }
     });
 }

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -1,0 +1,19 @@
+const cron = require('node-cron');
+const { topicService } = require('../src/services');
+const logger = require('./config/logger');
+
+const startJobs = () => {
+    cron.schedule('* * * * *', async () => {
+        logger.info('Starting deleteOldTopics job');
+        try {
+            const result = await topicService.deleteOldTopics();
+            logger.info(`Successfully deleted ${result.deletedCount} old topics.`);
+        } catch (err) {
+            logger.error('Error occurred in deleteOldTopics job: ', err);
+        }
+    });
+}
+
+module.exports = {
+    startJobs,
+};

--- a/src/models/token.model.js
+++ b/src/models/token.model.js
@@ -16,7 +16,7 @@ const tokenSchema = mongoose.Schema(
     },
     type: {
       type: String,
-      enum: [tokenTypes.REFRESH, tokenTypes.RESET_PASSWORD, tokenTypes.VERIFY_EMAIL],
+      enum: [tokenTypes.REFRESH, tokenTypes.RESET_PASSWORD, tokenTypes.VERIFY_EMAIL, tokenTypes.ARCHIVE_TOPIC],
       required: true,
     },
     expires: {

--- a/src/models/topic.model.js
+++ b/src/models/topic.model.js
@@ -38,6 +38,10 @@ const topicSchema = mongoose.Schema(
       type: Boolean,
       default: false,
     },
+    isArchiveNotified: {
+      type: Boolean,
+      default: false,
+    },
     owner: {
       type: mongoose.SchemaTypes.ObjectId,
       ref: 'User',

--- a/src/models/topic.model.js
+++ b/src/models/topic.model.js
@@ -32,6 +32,7 @@ const topicSchema = mongoose.Schema(
     },
     archived: {
       type: Boolean,
+      default: false,
     },
     owner: {
       type: mongoose.SchemaTypes.ObjectId,

--- a/src/models/topic.model.js
+++ b/src/models/topic.model.js
@@ -34,6 +34,10 @@ const topicSchema = mongoose.Schema(
       type: Boolean,
       default: false,
     },
+    isDeleted: {
+      type: Boolean,
+      default: false,
+    },
     owner: {
       type: mongoose.SchemaTypes.ObjectId,
       ref: 'User',

--- a/src/routes/v1/topics.route.js
+++ b/src/routes/v1/topics.route.js
@@ -168,4 +168,30 @@ router.route('/:topicId').get(topicController.getTopic);
  */
 router.route('/auth').post(validate(topicValidation.authenticate), topicController.authenticate);
 
+/**
+ * @swagger
+ * /topics/archive:
+ *   post:
+ *     description: Archive a topic, preventing it from being soft deleted
+ *     tags: [Topic]
+ *     produces:
+ *       - application/json
+ *     requestBody:
+ *       required: true
+ *       content: 
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               topicId:
+ *                 type: string
+ *               token:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: ok
+ *                      
+ */
+router.route('/archive').post(validate(topicValidation.archiveTopic), topicController.archiveTopic);
+
 module.exports = router;

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -55,9 +55,27 @@ If you did not create an account, then ignore this email.`;
   await sendEmail(to, subject, text);
 };
 
+/**
+ * Send email to user for channel archiving
+ * @param {string} to
+ * @param {Topic} topic
+ * @param {string} token
+ * @returns {Promise}
+ */
+ const sendArchiveTopicEmail = async (to, topic, token) => {
+  const subject = 'Archiving Your Threads Channel';
+  // replace this url with the link to the email verification page of your front-end app
+  const archivalUrl = `http://link-to-app/archive-topic?topicId=${topic._id}&token=${token}`;
+  const text = `Dear user,
+Your channel "${topic.name}" is now 90 days old, and will be archived and removed from Threads in 7 days.
+To prevent archival and keep your channel on Threads, please click on this link: ${archivalUrl}`;
+  await sendEmail(to, subject, text);
+};
+
 module.exports = {
   transport,
   sendEmail,
   sendResetPasswordEmail,
   sendVerificationEmail,
+  sendArchiveTopicEmail,
 };

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -64,8 +64,8 @@ If you did not create an account, then ignore this email.`;
  */
  const sendArchiveTopicEmail = async (to, topic, token) => {
   const subject = 'Archiving Your Threads Channel';
-  // replace this url with the link to the email verification page of your front-end app
-  const archivalUrl = `http://link-to-app/archive-topic?topicId=${topic._id}&token=${token}`;
+  // replace this url with the link to the archive topic page of your front-end app
+  const archivalUrl = `http://localhost:3000/archive-topic?topicId=${topic._id}&token=${token}`;
   const text = `Dear user,
 Your channel "${topic.name}" is now 90 days old, and will be archived and removed from Threads in 7 days.
 To prevent archival and keep your channel on Threads, please click on this link: ${archivalUrl}`;

--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -101,7 +101,7 @@ const generateVerifyEmailToken = async (user) => {
  */
  const generateArchiveTopicToken = async (user) => {
   const expires = moment().add(7, 'days');
-  const archiveTopicToken = await generateToken(user.id, expires, tokenTypes.VERIFY_EMAIL);
+  const archiveTopicToken = await generateToken(user.id, expires, tokenTypes.ARCHIVE_TOPIC);
   await saveToken(archiveTopicToken, user.id, expires, tokenTypes.ARCHIVE_TOPIC);
   return archiveTopicToken;
 };

--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -94,10 +94,23 @@ const generateVerifyEmailToken = async (user) => {
   return verifyEmailToken;
 };
 
+/**
+ * Generate archive topic token
+ * @param {User} user
+ * @returns {Promise<string>}
+ */
+ const generateArchiveTopicToken = async (user) => {
+  const expires = moment().add(7, 'days');
+  const archiveTopicToken = generateToken(user.id, expires, tokenTypes.VERIFY_EMAIL);
+  await saveToken(archiveTopicToken, user.id, expires, tokenTypes.ARCHIVE_TOPIC);
+  return archiveTopicToken;
+};
+
 module.exports = {
   generateToken,
   saveToken,
   verifyToken,
   generateAuthTokens,
   generateVerifyEmailToken,
+  generateArchiveTopicToken,
 };

--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -101,7 +101,7 @@ const generateVerifyEmailToken = async (user) => {
  */
  const generateArchiveTopicToken = async (user) => {
   const expires = moment().add(7, 'days');
-  const archiveTopicToken = generateToken(user.id, expires, tokenTypes.VERIFY_EMAIL);
+  const archiveTopicToken = await generateToken(user.id, expires, tokenTypes.VERIFY_EMAIL);
   await saveToken(archiveTopicToken, user.id, expires, tokenTypes.ARCHIVE_TOPIC);
   return archiveTopicToken;
 };

--- a/src/services/topic.service.js
+++ b/src/services/topic.service.js
@@ -132,7 +132,7 @@ const emailUsersToArchive = async() => {
   date.setDate(date.getDate() - 90);
   // Get all archivable topics
   const topics = await Topic.find({ isDeleted: false, archived: false, archivable: true, createdAt: { $gte: date } }).populate('owner');
-  topics.forEach((topic) => {
+  topics.forEach( async(topic) => {
     if (topic.owner.email) {
       const archiveToken = await tokenService.generateArchiveTopicToken(topic.owner);
       await emailService.sendArchiveTopicEmail(topic.owner.email, topic, archiveToken);

--- a/src/services/topic.service.js
+++ b/src/services/topic.service.js
@@ -120,11 +120,11 @@ const deleteOldTopics = async() => {
   date.setDate(date.getDate() - 97);
   // Get all deletable topics
   const topics = await Topic.find({ isDeleted: false, archived: false, createdAt: { $lte: date } });
-  topics.forEach((topic) => {
+  for (let x=0; x<topics.length; x++) {
     // Save topic as deleted
-    topic.isDeleted = true;
-    await topic.save();
-  });
+    topics[x].isDeleted = true;
+    await topics[x].save();
+  }
   return topics;
 };
 
@@ -139,13 +139,14 @@ const emailUsersToArchive = async() => {
     archivable: true, 
     createdAt: { $lte: date } }).populate('owner');
   topics = topics.filter(t => t.owner.email);
-  topics.forEach( async(topic) => {
+  for (let x=0; x<topics.length; x++) {
     // Email users prompting them to archive
+    let topic = topics[x];
     const archiveToken = await tokenService.generateArchiveTopicToken(topic.owner);
     await emailService.sendArchiveTopicEmail(topic.owner.email, topic, archiveToken);
     topic.isArchiveNotified = true;
     await topic.save();
-  });
+  };
   return topics;
 };
 

--- a/src/validations/topic.validation.js
+++ b/src/validations/topic.validation.js
@@ -16,7 +16,15 @@ const authenticate = {
   }),
 };
 
+const archiveTopic = {
+  body: Joi.object().keys({
+    topicId: Joi.string().required(),
+    token: Joi.string().required(),
+  }),
+};
+
 module.exports = {
   authenticate,
   createTopic,
+  archiveTopic,
 };

--- a/tests/fixtures/thread.fixture.js
+++ b/tests/fixtures/thread.fixture.js
@@ -2,8 +2,10 @@ const mongoose = require('mongoose');
 const faker = require('faker');
 const Thread = require('../../src/models/thread.model');
 const { userOne } = require('./user.fixture');
-const { publicTopic, privateTopic } = require('./topic.fixture');
+const { newPublicTopic, newPrivateTopic } = require('./topic.fixture');
 
+const publicTopic = newPublicTopic();
+const privateTopic = newPrivateTopic();
 
 const nameSlug1 = faker.lorem.word().toLowerCase();
 const nameSlug2 = faker.lorem.word().toLowerCase();
@@ -32,4 +34,6 @@ module.exports = {
   threadOne,
   threadTwo,
   insertThreads,
+  publicTopic,
+  privateTopic,
 };

--- a/tests/fixtures/topic.fixture.js
+++ b/tests/fixtures/topic.fixture.js
@@ -17,7 +17,8 @@ const topicPost = {
   archivable: true,
 };
 
-const publicTopic = {
+const newPublicTopic = () => { 
+  return {
     _id: mongoose.Types.ObjectId(),
     name: nameSlug,
     slug: nameSlug,
@@ -26,9 +27,13 @@ const publicTopic = {
     archivable: true,
     archived: false,
     owner: userOne._id,
+    isDeleted: false,
+    isArchiveNotified: false,
+  }
 };
 
-const privateTopic = {
+const newPrivateTopic = () => { 
+  return {
   _id: mongoose.Types.ObjectId(),
   name: nameSlug,
   slug: nameSlug,
@@ -38,6 +43,9 @@ const privateTopic = {
   archivable: true,
   archived: false,
   owner: userOne._id,
+  isDeleted: false,
+  isArchiveNotified: false,
+  }
 };
 
 const insertTopics = async (topics) => {
@@ -45,8 +53,8 @@ const insertTopics = async (topics) => {
 };
 
 module.exports = {
-  publicTopic,
-  privateTopic,
+  newPublicTopic,
+  newPrivateTopic,
   topicPost,
   insertTopics,
   getRandomInt,

--- a/tests/integration/message.test.js
+++ b/tests/integration/message.test.js
@@ -6,10 +6,11 @@ const { insertUsers, registeredUser, userOne } = require('../fixtures/user.fixtu
 const { registeredUserAccessToken, userOneAccessToken } = require('../fixtures/token.fixture');
 const httpStatus = require('http-status');
 const Message = require('../../src/models/message.model');
-const { insertTopics, publicTopic } = require('../fixtures/topic.fixture');
+const { insertTopics, newPublicTopic, newPrivateTopic } = require('../fixtures/topic.fixture');
 const { threadOne, insertThreads } = require('../fixtures/thread.fixture');
 
 setupTestDB();
+const publicTopic = newPublicTopic();
 
 describe('Message routes', () => {
     describe('POST /v1/messages/:threadId/upVote', () => {

--- a/tests/integration/thread.test.js
+++ b/tests/integration/thread.test.js
@@ -4,8 +4,8 @@ const request = require('supertest');
 const { insertUsers, userOne } = require('../fixtures/user.fixture');
 const { userOneAccessToken } = require('../fixtures/token.fixture');
 const httpStatus = require('http-status');
-const { topicPost, publicTopic, privateTopic, insertTopics, getRandomInt } = require('../fixtures/topic.fixture');
-const { threadOne, threadTwo, insertThreads } = require('../fixtures/thread.fixture');
+const { insertTopics } = require('../fixtures/topic.fixture');
+const { threadOne, threadTwo, insertThreads, publicTopic, privateTopic } = require('../fixtures/thread.fixture');
 const { messageOne, messageTwo, messageThree, insertMessages } = require('../fixtures/message.fixture');
 const faker = require('faker');
 

--- a/tests/services/topic.service.test.js
+++ b/tests/services/topic.service.test.js
@@ -1,0 +1,135 @@
+const setupTestDB = require('../utils/setupTestDB');
+const { insertUsers, userOne } = require('../fixtures/user.fixture');
+const { newPublicTopic, newPrivateTopic, insertTopics } = require('../fixtures/topic.fixture');
+const { topicService } = require('../../src/services');
+const Topic = require('../../src/models/topic.model');
+const { Token } = require('../../src/models');
+const { tokenTypes } = require('../../src/config/tokens');
+
+setupTestDB();
+
+let publicTopic;
+let privateTopic;
+
+beforeEach(() => {
+    publicTopic = newPublicTopic();
+    privateTopic = newPrivateTopic();
+});
+
+describe('Topic service methods', () => {
+    describe('deleteOldTopics()', () => {
+        // Set created date to 98 days ago
+        let oldDate = "";
+        beforeEach(() => {
+            const d = new Date();
+            d.setDate(d.getDate() - 98);
+            oldDate = d.toISOString();
+        });
+
+        test('should delete topics older than 97 days', async () => {
+            publicTopic.createdAt = oldDate;
+            const d = new Date();
+            d.setDate(d.getDate() - 96);
+            privateTopic.createdAt = d.toISOString();
+            await insertTopics([publicTopic, privateTopic]);
+
+            const ret = await topicService.deleteOldTopics();
+            expect(ret).toHaveLength(1);
+            expect(ret[0]._id).toEqual(publicTopic._id);
+
+            const dbPublicTopic = await Topic.findById(publicTopic._id);
+            expect(dbPublicTopic.isDeleted).toBe(true);
+
+            const dbPrivateTopic = await Topic.findById(privateTopic._id);
+            expect(dbPrivateTopic.isDeleted).toBe(false);
+        });
+
+        test('should not delete topics marked as archived and deleted', async () => {
+            publicTopic.createdAt = oldDate;
+            privateTopic.createdAt = oldDate;
+            publicTopic.archived = true;
+            privateTopic.isDeleted = true;
+
+            await insertTopics([publicTopic, privateTopic]);
+
+            const ret = await topicService.deleteOldTopics();
+            expect(ret).toHaveLength(0);
+
+            const dbPublicTopic = await Topic.findById(publicTopic._id);
+            expect(dbPublicTopic.isDeleted).toBe(false);
+        });
+    });
+
+    describe('emailUsersToArchive()', () => {
+        // Set created date to 98 days ago
+        let oldDate = "";
+        beforeEach(async() => {
+            const d = new Date();
+            d.setDate(d.getDate() - 91);
+            oldDate = d.toISOString();
+
+            await insertUsers([userOne]);
+        });
+
+        test('should generate token, email user, and mark as isArchiveNotified = true', async () => {
+            publicTopic.createdAt = oldDate;
+            const d = new Date();
+            d.setDate(d.getDate() - 88);
+            privateTopic.createdAt = d.toISOString();
+            await insertTopics([publicTopic, privateTopic]);
+
+            const ret = await topicService.emailUsersToArchive();
+            expect(ret).toHaveLength(1);
+            expect(ret[0]._id).toEqual(publicTopic._id);
+
+            const dbToken = await Token.find({ user: userOne, type: tokenTypes.ARCHIVE_TOPIC });
+            expect(dbToken).toBeTruthy();
+
+            // Todo: see if we can check existence of sent mail using ethereal
+
+            const dbPublicTopic = await Topic.findById(publicTopic._id);
+            expect(dbPublicTopic.isArchiveNotified).toBe(true);
+        });
+
+        test('should not send email if topic is not archivable', async () => {
+            publicTopic.createdAt = oldDate;
+            publicTopic.achivable = false;
+
+            await insertTopics([publicTopic]);
+
+            const ret = await topicService.deleteOldTopics();
+            expect(ret).toHaveLength(0);
+
+            const dbPublicTopic = await Topic.findById(publicTopic._id);
+            expect(dbPublicTopic.isArchiveNotified).toBe(false);
+        });
+
+        test('should not send email if email is already sent', async () => {
+            publicTopic.createdAt = oldDate;
+            publicTopic.isArchiveNotified = true;
+
+            await insertTopics([publicTopic]);
+
+            const ret = await topicService.deleteOldTopics();
+            expect(ret).toHaveLength(0);
+        });
+
+        test('should not send email if topic is deleted or archived', async () => {
+            publicTopic.createdAt = oldDate;
+            privateTopic.createdAt = oldDate;
+            publicTopic.archived = true;
+            privateTopic.isDeleted = true;
+
+            await insertTopics([publicTopic, privateTopic]);
+
+            const ret = await topicService.deleteOldTopics();
+            expect(ret).toHaveLength(0);
+
+            const dbPublicTopic = await Topic.findById(publicTopic._id);
+            expect(dbPublicTopic.isArchiveNotified).toBe(false);
+
+            const dbPrivateTopic = await Topic.findById(privateTopic._id);
+            expect(dbPrivateTopic.isArchiveNotified).toBe(false);
+        });
+    });
+});

--- a/tests/services/user.service.test.js
+++ b/tests/services/user.service.test.js
@@ -1,0 +1,90 @@
+const setupTestDB = require('../utils/setupTestDB');
+const { insertUsers, registeredUser } = require('../fixtures/user.fixture');
+const { insertMessages, messageOne } = require('../fixtures/message.fixture');
+const userService = require('../../src/services/user.service');
+const mongoose = require('mongoose');
+
+
+setupTestDB();
+
+const createVote = () => {
+    return {
+      _id: mongoose.Types.ObjectId(),
+      owner: mongoose.Types.ObjectId()
+    };
+};
+
+describe('User service methods', () => {
+
+    describe('goodReputation()', () => {
+      beforeEach(() => {
+        // Add five upvotes
+        messageOne.upVotes = [];
+        for (let x=0; x<5; x++) {
+          messageOne.upVotes.push(createVote());
+        }
+      });
+  
+      test('should return true if user vote score < -5 and account is more than 1 week old', async () => {
+        // Set created date to > week ago
+        const d = new Date();
+        d.setDate(d.getDate() - 8);
+        registeredUser.createdAt = d.toISOString();
+        await insertUsers([registeredUser]);
+        await insertMessages([messageOne]);
+  
+        registeredUser.id = registeredUser._id;
+        const goodReputation = await userService.goodReputation(registeredUser);
+        expect(goodReputation).toBe(true);
+      });
+  
+      test('should return false if user vote score < -5', async () => {
+        // Set created date to > week ago
+        const d = new Date();
+        d.setDate(d.getDate() - 8);
+        registeredUser.createdAt = d.toISOString();
+        await insertUsers([registeredUser]);
+        messageOne.downVotes = [];
+        // Add eleven downvotes
+        for (let x=0; x<11; x++) {
+          messageOne.downVotes.push(createVote());
+        }
+        await insertMessages([messageOne]);
+        registeredUser.id = registeredUser._id;
+  
+        const goodReputation = await userService.goodReputation(registeredUser);
+        expect(goodReputation).toBe(false);
+      });
+  
+      test('should return false if user account is less than one week old', async () => {
+        // Set created date to > week ago
+        const d = new Date();
+        registeredUser.createdAt = d.toISOString();
+        await insertUsers([registeredUser]);
+        await insertMessages([messageOne]);
+        registeredUser.id = registeredUser._id;
+  
+        const goodReputation = await userService.goodReputation(registeredUser);
+        expect(goodReputation).toBe(false);
+      });
+  
+      test('should return false if user account is less than one week old user vote score < -5', async () => {
+        // Set created date to > week ago
+        const d = new Date();
+        registeredUser.createdAt = d.toISOString();
+        await insertUsers([registeredUser]);
+        messageOne.downVotes = [];
+        // Add eleven downvotes
+        for (let x=0; x<11; x++) {
+          messageOne.downVotes.push(createVote());
+        }
+        await insertMessages([messageOne]);
+        registeredUser.id = registeredUser._id;
+  
+        const goodReputation = await userService.goodReputation(registeredUser);
+        expect(goodReputation).toBe(false);
+      });
+  
+    });
+  
+  });


### PR DESCRIPTION
- Created daily job using node-cron that emails users prompting them to archive topics that are older than 90 days, and deletes Topics older than 97 days that have not been archived
- Added services and `/topics/archive` endpoint to support the above jobs
- Implemented soft deletes for Topics; adjusted Topic queries accordingly
- Added tests for new service methods and endpoint

Note: This feature routes users to the front end, specifically `http://localhost:3000/archive-topic?topicId=${topic._id}&token=${token}`. The front end will need to receive that request and then forward a request to `/topics/archive` to properly archive the Topic.