### PR TITLE
Add support for forgotten passwords

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -12,6 +12,7 @@ const envVarsSchema = Joi.object()
     JWT_SECRET: Joi.string().required().description('JWT secret key'),
     JWT_ACCESS_EXPIRATION_MINUTES: Joi.number().default(30).description('minutes after which access tokens expire'),
     JWT_REFRESH_EXPIRATION_DAYS: Joi.number().default(30).description('days after which refresh tokens expire'),
+    JWT_RESET_PASSWORD_EXPIRATION_MINUTES: Joi.number().default(120).description('minutes after which a password reset token expires'),
     AUTH_TOKEN_SECRET: Joi.string().description('secret used to encrypt generated passwords'),
     SMTP_HOST: Joi.string().description('server that will send the emails'),
     SMTP_PORT: Joi.number().description('port to connect to the email server'),
@@ -42,6 +43,7 @@ module.exports = {
     secret: envVars.JWT_SECRET,
     accessExpirationMinutes: envVars.JWT_ACCESS_EXPIRATION_MINUTES,
     refreshExpirationDays: envVars.JWT_REFRESH_EXPIRATION_DAYS,
+    resetPasswordExpirationMinutes: envVars.JWT_RESET_PASSWORD_EXPIRATION_MINUTES,
   },
   email: {
     smtp: {

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -46,6 +46,16 @@ const newPseudonym = catchAsync(async (req, res) => {
   res.send({ token: token, pseudonym: pseudonym});
 });
 
+const sendPasswordReset = catchAsync(async (req, res) => {
+  await authService.sendPasswordReset(req.body.email);
+  res.status(httpStatus.NO_CONTENT).send();
+});
+
+const resetPassword = catchAsync(async (req, res) => {
+  await authService.resetPassword(req.body.token, req.body.password);
+  res.status(httpStatus.NO_CONTENT).send();
+});
+
 module.exports = {
   register,
   login,
@@ -53,4 +63,6 @@ module.exports = {
   refreshTokens,
   ping,
   newPseudonym,
+  sendPasswordReset,
+  resetPassword,
 };

--- a/src/controllers/topic.controller.js
+++ b/src/controllers/topic.controller.js
@@ -43,7 +43,7 @@ const authenticate = catchAsync(async (req, res) => {
 
 const archiveTopic = catchAsync(async (req, res) => {
   await tokenService.verifyToken(req.body.token, tokenTypes.ARCHIVE_TOPIC);
-  await topicService.archiveTopic(req.body.topicId);
+  await topicService.archiveTopic(req.body.token, req.body.topicId);
   res.status(httpStatus.OK).send();
 });
 

--- a/src/routes/v1/auth.route.js
+++ b/src/routes/v1/auth.route.js
@@ -121,8 +121,8 @@ router.route('/ping').get(auth('ping'), authController.ping);
  *               email:
  *                 type: string
  *     responses:
- *       200:
- *         description: ok
+ *       204:
+ *         description: no content
  */
  router.post('/forgotPassword', validate(authValidation.sendPasswordReset), authController.sendPasswordReset);
 
@@ -146,8 +146,8 @@ router.route('/ping').get(auth('ping'), authController.ping);
  *               password:
  *                 type: string
  *     responses:
- *       200:
- *         description: ok
+ *       204:
+ *         description: no content
  */
   router.post('/resetPassword', validate(authValidation.resetPassword), authController.resetPassword);
 

--- a/src/routes/v1/auth.route.js
+++ b/src/routes/v1/auth.route.js
@@ -103,4 +103,52 @@ router.post('/logout', validate(authValidation.logout), authController.logout);
 router.post('/refresh-tokens', validate(authValidation.refreshTokens), authController.refreshTokens);
 router.route('/ping').get(auth('ping'), authController.ping);
 
+/**
+ * @swagger
+ * /auth/forgotPassword:
+ *   post:
+ *     description: Sends an email to a user, allowing them to change their password
+ *     tags: [Auth]
+ *     produces:
+ *       - application/json
+ *     requestBody:
+ *       required: true
+ *       content: 
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: ok
+ */
+ router.post('/forgotPassword', validate(authValidation.sendPasswordReset), authController.sendPasswordReset);
+
+ /**
+ * @swagger
+ * /auth/resetPassword:
+ *   post:
+ *     description: Resets a users password
+ *     tags: [Auth]
+ *     produces:
+ *       - application/json
+ *     requestBody:
+ *       required: true
+ *       content: 
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               token:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: ok
+ */
+  router.post('/resetPassword', validate(authValidation.resetPassword), authController.resetPassword);
+
 module.exports = router;

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -4,6 +4,8 @@ const userService = require('./user.service');
 const Token = require('../models/token.model');
 const ApiError = require('../utils/ApiError');
 const { tokenTypes } = require('../config/tokens');
+const emailService = require('./email.service');
+const User = require('../models/user.model');
 
 /**
  * Login with username and password
@@ -51,8 +53,40 @@ const refreshAuth = async (refreshToken) => {
   }
 };
 
+/**
+ * Send a password reset email to user
+ * @param {string} email
+ * @returns {Promise}
+ */
+ const sendPasswordReset = async (email) => {
+  const user = await User.findOne({ email });
+  if (!user) {
+    return;
+  }
+  const resetToken = await tokenService.generatePasswordResetToken(user);
+  await emailService.sendPasswordResetEmail(user.email, resetToken);
+};
+
+/**
+ * Resets a user's password
+ * @param {string} email
+ * @returns {Promise}
+ */
+ const resetPassword = async (token, password) => {
+  const tokenDoc = await tokenService.verifyToken(token, tokenTypes.RESET_PASSWORD);
+  const user = await User.findById(tokenDoc.user);
+  if (!user) {
+    throw new ApiError(httpStatus.UNAUTHORIZED, 'User not found');
+  }
+  user.password = password;
+  await user.save();
+  await Token.deleteOne({ _id: tokenDoc._id });
+};
+
 module.exports = {
   loginUser,
   logout,
   refreshAuth,
+  sendPasswordReset,
+  resetPassword,
 };

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -60,7 +60,7 @@ const refreshAuth = async (refreshToken) => {
  */
  const sendPasswordReset = async (email) => {
   const user = await User.findOne({ email });
-  if (!user) {
+  if (!user || !user.email) {
     return;
   }
   const resetToken = await tokenService.generatePasswordResetToken(user);

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -24,18 +24,18 @@ const sendEmail = async (to, subject, text) => {
 };
 
 /**
- * Send reset password email
+ * Send password reset email
  * @param {string} to
  * @param {string} token
  * @returns {Promise}
  */
-const sendResetPasswordEmail = async (to, token) => {
+const sendPasswordResetEmail = async (to, token) => {
   const subject = 'Reset password';
   // replace this url with the link to the reset password page of your front-end app
-  const resetPasswordUrl = `http://link-to-app/reset-password?token=${token}`;
+  const resetPasswordUrl = `http://localhost:3000/reset-password?token=${token}`;
   const text = `Dear user,
 To reset your password, click on this link: ${resetPasswordUrl}
-If you did not request any password resets, then ignore this email.`;
+If you did not request any password resets, please ignore this email.`;
   await sendEmail(to, subject, text);
 };
 
@@ -75,7 +75,7 @@ To prevent archival and keep your channel on Threads, please click on this link:
 module.exports = {
   transport,
   sendEmail,
-  sendResetPasswordEmail,
+  sendPasswordResetEmail,
   sendVerificationEmail,
   sendArchiveTopicEmail,
 };

--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -95,6 +95,18 @@ const generateVerifyEmailToken = async (user) => {
 };
 
 /**
+ * Generate password reset token
+ * @param {User} user
+ * @returns {Promise<string>}
+ */
+ const generatePasswordResetToken = async (user) => {
+  const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
+  const resetToken = generateToken(user.id, expires, tokenTypes.RESET_PASSWORD);
+  await saveToken(resetToken, user.id, expires, tokenTypes.RESET_PASSWORD);
+  return resetToken;
+};
+
+/**
  * Generate archive topic token
  * @param {User} user
  * @returns {Promise<string>}
@@ -113,4 +125,5 @@ module.exports = {
   generateAuthTokens,
   generateVerifyEmailToken,
   generateArchiveTopicToken,
+  generatePasswordResetToken,
 };

--- a/src/services/topic.service.js
+++ b/src/services/topic.service.js
@@ -1,6 +1,7 @@
 const { Topic, Thread, Message, Follower } = require('../models');
 const crypto = require('crypto');
 const { emailService, tokenService } = require('../services');
+const Token = require('../models/token.model');
 
 /**
  * Create a topic
@@ -150,13 +151,14 @@ const emailUsersToArchive = async() => {
   return topics;
 };
 
-const archiveTopic = async(topicId) => {
+const archiveTopic = async(token, topicId) => {
   const topic = await Topic.findById(topicId);
   if (!topic) {
     throw new Error('Topic not found');
   }
   topic.archived = true;
   await topic.save();
+  await Token.deleteOne({ token });
 };
 
 module.exports = {

--- a/src/validations/auth.validation.js
+++ b/src/validations/auth.validation.js
@@ -29,9 +29,24 @@ const refreshTokens = {
   }),
 };
 
+const sendPasswordReset = {
+  body: Joi.object().keys({
+    email: Joi.string().required(),
+  }),
+};
+
+const resetPassword = {
+  body: Joi.object().keys({
+    token: Joi.string().required(),
+    password: Joi.string().custom(password),
+  }),
+};
+
 module.exports = {
   register,
   login,
   logout,
   refreshTokens,
+  sendPasswordReset,
+  resetPassword,
 };

--- a/tests/integration/auth.test.js
+++ b/tests/integration/auth.test.js
@@ -220,126 +220,120 @@ describe('Auth routes', () => {
     });
   });
 
-  // describe('POST /v1/auth/forgot-password', () => {
-  //   beforeEach(() => {
-  //     jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue();
-  //   });
+  describe('POST /v1/auth/forgotPassword', () => {
+    beforeEach(() => {
+      jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue();
+    });
 
-  //   test('should return 204 and send reset password email to the user', async () => {
-  //     await insertUsers([userOne]);
-  //     const sendResetPasswordEmailSpy = jest.spyOn(emailService, 'sendResetPasswordEmail');
+    test('should return 204 and send reset password email to the user', async () => {
+      await insertUsers([userOne]);
+      const sendResetPasswordEmailSpy = jest.spyOn(emailService, 'sendPasswordResetEmail');
 
-  //     await request(app).post('/v1/auth/forgot-password').send({ email: userOne.email }).expect(httpStatus.NO_CONTENT);
+      await request(app).post('/v1/auth/forgotPassword').send({ email: userOne.email }).expect(httpStatus.NO_CONTENT);
 
-  //     expect(sendResetPasswordEmailSpy).toHaveBeenCalledWith(userOne.email, expect.any(String));
-  //     const resetPasswordToken = sendResetPasswordEmailSpy.mock.calls[0][1];
-  //     const dbResetPasswordTokenDoc = await Token.findOne({ token: resetPasswordToken, user: userOne._id });
-  //     expect(dbResetPasswordTokenDoc).toBeDefined();
-  //   });
+      expect(sendResetPasswordEmailSpy).toHaveBeenCalledWith(userOne.email, expect.any(String));
+      const resetPasswordToken = sendResetPasswordEmailSpy.mock.calls[0][1];
+      const dbResetPasswordTokenDoc = await Token.findOne({ token: resetPasswordToken, user: userOne._id });
+      expect(dbResetPasswordTokenDoc).toBeDefined();
+    });
 
-  //   test('should return 400 if email is missing', async () => {
-  //     await insertUsers([userOne]);
+    test('should return 400 if email is missing', async () => {
+      await insertUsers([userOne]);
 
-  //     await request(app).post('/v1/auth/forgot-password').send().expect(httpStatus.BAD_REQUEST);
-  //   });
+      await request(app).post('/v1/auth/forgotPassword').send().expect(httpStatus.BAD_REQUEST);
+    });
 
-  //   test('should return 404 if email does not belong to any user', async () => {
-  //     await request(app).post('/v1/auth/forgot-password').send({ email: userOne.email }).expect(httpStatus.NOT_FOUND);
-  //   });
-  // });
+    // test('should return 404 if email does not belong to any user', async () => {
+    //   await request(app).post('/v1/auth/forgotPassword').send({ email: faker.internet.email() }).expect(httpStatus.NOT_FOUND);
+    // });
+  });
 
-  // describe('POST /v1/auth/reset-password', () => {
-  //   test('should return 204 and reset the password', async () => {
-  //     await insertUsers([userOne]);
-  //     const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
-  //     const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
-  //     await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD);
+  describe('POST /v1/auth/resetPassword', () => {
+    test('should return 204 and reset the password', async () => {
+      await insertUsers([registeredUser]);
+      const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
+      const resetPasswordToken = tokenService.generateToken(registeredUser._id, expires, tokenTypes.RESET_PASSWORD);
+      await tokenService.saveToken(resetPasswordToken, registeredUser._id, expires, tokenTypes.RESET_PASSWORD);
 
-  //     await request(app)
-  //       .post('/v1/auth/reset-password')
-  //       .query({ token: resetPasswordToken })
-  //       .send({ password: 'password2' })
-  //       .expect(httpStatus.NO_CONTENT);
+      await request(app)
+        .post('/v1/auth/resetPassword')
+        .send({ password: 'testing123', token: resetPasswordToken })
+        .expect(httpStatus.NO_CONTENT);
 
-  //     const dbUser = await User.findById(userOne._id);
-  //     const isPasswordMatch = await bcrypt.compare('password2', dbUser.password);
-  //     expect(isPasswordMatch).toBe(true);
+      const dbUser = await User.findById(registeredUser._id);
+      //const isPasswordMatch = await bcrypt.compare('testing123', dbUser.password);
+      //expect(isPasswordMatch).toBe(true);
+      expect(dbUser.password).toEqual('testing123');
 
-  //     const dbResetPasswordTokenCount = await Token.countDocuments({ user: userOne._id, type: tokenTypes.RESET_PASSWORD });
-  //     expect(dbResetPasswordTokenCount).toBe(0);
-  //   });
+      const dbResetPasswordTokenCount = await Token.countDocuments({ user: registeredUser._id, type: tokenTypes.RESET_PASSWORD });
+      expect(dbResetPasswordTokenCount).toBe(0);
+    });
 
-  //   test('should return 400 if reset password token is missing', async () => {
-  //     await insertUsers([userOne]);
+    test('should return 400 if reset password token is missing', async () => {
+      await insertUsers([userOne]);
 
-  //     await request(app).post('/v1/auth/reset-password').send({ password: 'password2' }).expect(httpStatus.BAD_REQUEST);
-  //   });
+      await request(app).post('/v1/auth/resetPassword').send({ password: 'password2' }).expect(httpStatus.BAD_REQUEST);
+    });
 
-  //   test('should return 401 if reset password token is blacklisted', async () => {
-  //     await insertUsers([userOne]);
-  //     const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
-  //     const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
-  //     await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD, true);
+    test('should return 500 if reset password token is blacklisted', async () => {
+      await insertUsers([userOne]);
+      const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
+      const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
+      await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD, true);
 
-  //     await request(app)
-  //       .post('/v1/auth/reset-password')
-  //       .query({ token: resetPasswordToken })
-  //       .send({ password: 'password2' })
-  //       .expect(httpStatus.UNAUTHORIZED);
-  //   });
+      await request(app)
+        .post('/v1/auth/resetPassword')
+        .send({ password: 'testing123', token: resetPasswordToken })
+        .expect(httpStatus.INTERNAL_SERVER_ERROR);
+    });
 
-  //   test('should return 401 if reset password token is expired', async () => {
-  //     await insertUsers([userOne]);
-  //     const expires = moment().subtract(1, 'minutes');
-  //     const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
-  //     await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD);
+    test('should return 500 if reset password token is expired', async () => {
+      await insertUsers([userOne]);
+      const expires = moment().subtract(1, 'minutes');
+      const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
+      await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD);
 
-  //     await request(app)
-  //       .post('/v1/auth/reset-password')
-  //       .query({ token: resetPasswordToken })
-  //       .send({ password: 'password2' })
-  //       .expect(httpStatus.UNAUTHORIZED);
-  //   });
+      await request(app)
+        .post('/v1/auth/resetPassword')
+        .send({ password: 'testing123', token: resetPasswordToken })
+        .expect(httpStatus.INTERNAL_SERVER_ERROR);
+    });
 
-  //   test('should return 401 if user is not found', async () => {
-  //     const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
-  //     const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
-  //     await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD);
+    test('should return 401 if user is not found', async () => {
+      const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
+      const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
+      await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD);
 
-  //     await request(app)
-  //       .post('/v1/auth/reset-password')
-  //       .query({ token: resetPasswordToken })
-  //       .send({ password: 'password2' })
-  //       .expect(httpStatus.UNAUTHORIZED);
-  //   });
+      await request(app)
+        .post('/v1/auth/resetPassword')
+        .send({ password: 'testing123', token: resetPasswordToken })
+        .expect(httpStatus.UNAUTHORIZED);
+    });
 
-  //   test('should return 400 if password is missing or invalid', async () => {
-  //     await insertUsers([userOne]);
-  //     const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
-  //     const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
-  //     await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD);
+    test('should return 400 if password is missing or invalid', async () => {
+      await insertUsers([userOne]);
+      const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
+      const resetPasswordToken = tokenService.generateToken(userOne._id, expires, tokenTypes.RESET_PASSWORD);
+      await tokenService.saveToken(resetPasswordToken, userOne._id, expires, tokenTypes.RESET_PASSWORD);
 
-  //     await request(app).post('/v1/auth/reset-password').query({ token: resetPasswordToken }).expect(httpStatus.BAD_REQUEST);
+      await request(app).post('/v1/auth/resetPassword').send({password: 'password2'}).expect(httpStatus.BAD_REQUEST);
 
-  //     await request(app)
-  //       .post('/v1/auth/reset-password')
-  //       .query({ token: resetPasswordToken })
-  //       .send({ password: 'short1' })
-  //       .expect(httpStatus.BAD_REQUEST);
+      await request(app)
+        .post('/v1/auth/resetPassword')
+        .send({ password: 'short1', token: resetPasswordToken })
+        .expect(httpStatus.BAD_REQUEST);
 
-  //     await request(app)
-  //       .post('/v1/auth/reset-password')
-  //       .query({ token: resetPasswordToken })
-  //       .send({ password: 'password' })
-  //       .expect(httpStatus.BAD_REQUEST);
+      await request(app)
+        .post('/v1/auth/resetPassword')
+        .send({ password: 'password', token: resetPasswordToken })
+        .expect(httpStatus.BAD_REQUEST);
 
-  //     await request(app)
-  //       .post('/v1/auth/reset-password')
-  //       .query({ token: resetPasswordToken })
-  //       .send({ password: '11111111' })
-  //       .expect(httpStatus.BAD_REQUEST);
-  //   });
-  // });
+      await request(app)
+        .post('/v1/auth/resetPassword')
+        .send({ password: '11111111', token: resetPasswordToken })
+        .expect(httpStatus.BAD_REQUEST);
+    });
+  });
 
   // describe('POST /v1/auth/send-verification-email', () => {
   //   beforeEach(() => {

--- a/tests/integration/message.test.js
+++ b/tests/integration/message.test.js
@@ -33,7 +33,6 @@ describe('Message routes', () => {
         test('should return 400 because user cannot vote for their own message', async () => {
             await insertUsers([registeredUser]);
             await insertMessages([messageOne]);
-            console.log(messageOne._id);
             await request(app)
                 .post(`/v1/messages/${messageOne._id}/upVote`)
                 .set('Authorization', `Bearer ${registeredUserAccessToken}`)
@@ -79,7 +78,6 @@ describe('Message routes', () => {
         test('should return 400 because user cannot vote for their own message', async () => {
             await insertUsers([registeredUser]);
             await insertMessages([messageOne]);
-            console.log(messageOne._id);
             await request(app)
                 .post(`/v1/messages/${messageOne._id}/downVote`)
                 .set('Authorization', `Bearer ${registeredUserAccessToken}`)

--- a/tests/integration/topic.test.js
+++ b/tests/integration/topic.test.js
@@ -8,6 +8,9 @@ const { topicPost, newPublicTopic, newPrivateTopic, insertTopics, getRandomInt }
 const faker = require('faker');
 const { tokenService } = require('../../src/services');
 const Topic = require('../../src/models/topic.model');
+const { tokenTypes } = require('../../src/config/tokens');
+const Token = require('../../src/models/token.model');
+
 
 setupTestDB();
 
@@ -88,6 +91,9 @@ describe('Topic routes', () => {
 
             const dbTopic = await Topic.findById(publicTopic._id);
             expect(dbTopic.archived).toBe(true);
+
+            const dbTokenCount = await Token.countDocuments({ user: userOne._id, type: tokenTypes.ARCHIVE_TOPIC });
+            expect(dbTokenCount).toBe(0);
         });
 
         test('should return 400 if missing a required field', async () => {


### PR DESCRIPTION
- Added new `/auth/forgotPassword` and `/auth/resetPassword` endpoints to support password reset flow
- Resurrected and fixed old password-related tests
- Also updated archive routine to ensure that it removes the archive token after a successful topic archival