### PR TITLE
Separate follows/pins for channels and threads

### DIFF
--- a/src/config/roles.js
+++ b/src/config/roles.js
@@ -9,6 +9,7 @@ const allRoles = {
     'userThreads',
     'ping',
     'followThread',
+    'followTopic',
     'getThread',
     'allTopics',
     'publicThreads',

--- a/src/controllers/topic.controller.js
+++ b/src/controllers/topic.controller.js
@@ -19,6 +19,11 @@ const userTopics = catchAsync(async (req, res) => {
   res.status(httpStatus.OK).send(topics);
 });
 
+const follow = catchAsync(async (req, res) => {
+  await topicService.follow(req.body.status, req.body.topicId, req.user);
+  res.status(httpStatus.OK).send('ok');
+});
+
 const getTopic = catchAsync(async (req, res) => {
   const topic = await topicService.findById(req.params.topicId);
   res.status(httpStatus.OK).send(topic);
@@ -67,4 +72,5 @@ module.exports = {
   authenticate,
   archiveTopic,
   deleteTopic,
+  follow,
 };

--- a/src/models/topic.model.js
+++ b/src/models/topic.model.js
@@ -51,6 +51,7 @@ const topicSchema = mongoose.Schema(
       required: true,
     },
     threads: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'Thread' }],
+    followers: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'Follower' }],
   },
   {
     timestamps: true,

--- a/src/routes/v1/topics.route.js
+++ b/src/routes/v1/topics.route.js
@@ -243,4 +243,6 @@ router.route('/auth').post(validate(topicValidation.authenticate), topicControll
  */
 router.route('/archive').post(validate(topicValidation.archiveTopic), topicController.archiveTopic);
 
+router.route('/follow').post(auth('followTopic'), topicController.follow);
+
 module.exports = router;

--- a/src/services/thread.service.js
+++ b/src/services/thread.service.js
@@ -43,7 +43,7 @@ const createThread = async (threadBody, user) => {
 const userThreads = async (user) => {
   const deletedTopics = await Topic.find({ isDeleted: true }).select('_id');
   const followedThreads = await Follower.find({ user }).select('thread').exec();
-  const followedThreadsIds = followedThreads.map((el) => el.thread);
+  const followedThreadsIds = followedThreads.map((el) => el.thread).filter((el) => el);
   let threads = await Thread.find({
     $and: [
       { $or: [{ owner: user }, { _id: { $in: followedThreadsIds } }] },
@@ -56,7 +56,6 @@ const userThreads = async (user) => {
     .select('name slug')
     .exec();
   threads = addMessageCount(threads);
-  console.log(followedThreadsIds);
   threads.forEach((thread) => {
     if (followedThreadsIds.map(f => f.toString()).includes(thread.id)){
       thread.followed = true;

--- a/tests/fixtures/follower.fixture.js
+++ b/tests/fixtures/follower.fixture.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+const Follower = require('../../src/models/follower.model');
+const { userOne } = require('./user.fixture');
+const { threadThree } = require('./thread.fixture');
+const { newPublicTopic } = require('./topic.fixture');
+
+const topicOne = newPublicTopic();
+
+const threadFollow = {
+  _id: mongoose.Types.ObjectId(),
+  user: userOne._id,
+  thread: threadThree._id,
+};
+
+const insertFollowers = async (followers) => {
+  const ret = await Follower.insertMany(followers);
+  return ret;
+};
+
+module.exports = {
+  threadFollow,
+  insertFollowers,
+};

--- a/tests/fixtures/thread.fixture.js
+++ b/tests/fixtures/thread.fixture.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 const faker = require('faker');
 const Thread = require('../../src/models/thread.model');
-const { userOne } = require('./user.fixture');
+const { userOne, userTwo } = require('./user.fixture');
 const { newPublicTopic, newPrivateTopic } = require('./topic.fixture');
 
 const publicTopic = newPublicTopic();
@@ -9,6 +9,7 @@ const privateTopic = newPrivateTopic();
 
 const nameSlug1 = faker.lorem.word().toLowerCase();
 const nameSlug2 = faker.lorem.word().toLowerCase();
+const nameSlug3 = faker.lorem.word().toLowerCase();
 
 const threadOne = {
   _id: mongoose.Types.ObjectId(),
@@ -26,6 +27,14 @@ const threadTwo = {
   topic: privateTopic._id,
 };
 
+const threadThree = {
+  _id: mongoose.Types.ObjectId(),
+  name: nameSlug3,
+  slug: nameSlug3,
+  owner: userTwo._id,
+  topic: privateTopic._id,
+};
+
 const insertThreads = async (threads) => {
   await Thread.insertMany(threads);
 };
@@ -33,6 +42,7 @@ const insertThreads = async (threads) => {
 module.exports = {
   threadOne,
   threadTwo,
+  threadThree,
   insertThreads,
   publicTopic,
   privateTopic,


### PR DESCRIPTION
- Added new follow endpoint for channels
- Updated `userThreads` and `userTopics` endpoints to differentiate between owned and followed channels/threads using `followed` property
- Ensured Mongo queries are correct given shared Follower document for both topics and threads