### PR TITLE
Change archive and delete jobs to target 90 97 days of inactivity

### DIFF
--- a/tests/fixtures/thread.fixture.js
+++ b/tests/fixtures/thread.fixture.js
@@ -17,6 +17,7 @@ const threadOne = {
   slug: nameSlug1,
   owner: userOne._id,
   topic: publicTopic._id,
+  messages: [],
 };
 
 const threadTwo = {

--- a/tests/fixtures/topic.fixture.js
+++ b/tests/fixtures/topic.fixture.js
@@ -29,6 +29,7 @@ const newPublicTopic = () => {
     owner: userOne._id,
     isDeleted: false,
     isArchiveNotified: false,
+    threads: [],
   };
 };
 
@@ -45,6 +46,7 @@ const newPrivateTopic = () => {
     owner: userOne._id,
     isDeleted: false,
     isArchiveNotified: false,
+    threads: [],
   };
 };
 


### PR DESCRIPTION
The jobs that 1) delete topics older than 97 days, and 2) email users to archive topics older than 90 days, now both use recent message activity to define "old", instead of topic creation date.