### PR TITLE
Refactored websocket, allowing for new votes and threads to be broadcasted.

### DIFF
--- a/src/controllers/message.controller.js
+++ b/src/controllers/message.controller.js
@@ -1,6 +1,7 @@
 const httpStatus = require('http-status');
 const catchAsync = require('../utils/catchAsync');
 const { messageService } = require('../services');
+const { io } = require('../websockets/index');
 
 const createMessage = catchAsync(async (req, res) => {
   const message = await messageService.createMessage(req.body, req.user);
@@ -14,6 +15,7 @@ const threadMessages = catchAsync(async (req, res) => {
 
 const vote = catchAsync(async (req, res) => {
   const message = await messageService.vote(req.params.messageId, req.body.direction, req.body.status, req.user);
+  io.in(message.thread._id.toString()).emit('vote:new', message);
   res.status(httpStatus.OK).send(message);
 });
 

--- a/src/controllers/thread.controller.js
+++ b/src/controllers/thread.controller.js
@@ -1,9 +1,11 @@
 const httpStatus = require('http-status');
 const catchAsync = require('../utils/catchAsync');
 const { threadService } = require('../services');
+const { io } = require('../websockets/index');
 
 const createThread = catchAsync(async (req, res) => {
   const thread = await threadService.createThread(req.body, req.user);
+  io.in(thread.topic._id.toString()).emit('thread:new', thread);
   res.status(httpStatus.CREATED).send(thread);
 });
 

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -328,7 +328,7 @@ const goodReputation = async (user) => {
   }
   // Subtract downvotes from upvotes for "reputation score"
   const reputationScore = totalUpVotes - totalDownVotes;
-  // Calculate weeks since account creation
+  // Calculate days since account creation
   const today = new Date();
   const createdDate = new Date(user.createdAt); 
   const days = Math.round((today - createdDate) / 86400000);

--- a/src/websockets/index.js
+++ b/src/websockets/index.js
@@ -7,11 +7,17 @@ const io = require('socket.io')(httpServer, {
   },
 });
 const registerMessageHandlers = require('./messageHandlers');
+const registerThreadHandlers = require('./threadHandlers');
 
 const onConnection = (socket) => {
   registerMessageHandlers(io, socket);
+  registerThreadHandlers(io, socket);
 };
 
 io.on('connection', onConnection);
 
 if (config.env !== 'test') httpServer.listen(5555);
+
+module.exports = {
+  io,
+};

--- a/src/websockets/messageHandlers.js
+++ b/src/websockets/messageHandlers.js
@@ -1,31 +1,16 @@
-const jwt = require('jsonwebtoken');
-const config = require('../config/config');
 const { messageService } = require('../services');
 const catchAsync = require('../utils/catchAsync');
-const { User } = require('../models');
+const { checkAuth } = require('./utils');
 
 module.exports = (io, socket) => {
-  let user = null;
-
   const createMessage = catchAsync(async (data) => {
-    const message = await messageService.createMessage(data.message, user);
-    message.owner = user._id;
+    const message = await messageService.createMessage(data.message, data.user);
+    message.owner = data.user._id;
     io.in(message.thread._id.toString()).emit('message:new', message);
   });
 
   const joinThread = catchAsync(async (data) => {
     socket.join(data.threadId.toString());
-  });
-
-  const checkAuth = catchAsync(async (event, args, next) => {
-    try {
-      const payload = jwt.verify(args.token, config.jwt.secret);
-      user = await User.findById(payload.sub);
-    } catch (e) {
-      return;
-    }
-
-    next();
   });
 
   socket.use(([event, args], next) => {

--- a/src/websockets/threadHandlers.js
+++ b/src/websockets/threadHandlers.js
@@ -1,0 +1,14 @@
+const catchAsync = require('../utils/catchAsync');
+const { checkAuth } = require('./utils');
+
+module.exports = (io, socket) => {
+  const joinTopic = catchAsync(async (data) => {
+    socket.join(data.topicId.toString());
+  });
+
+  socket.use(([event, args], next) => {
+    checkAuth(event, args, next);
+  });
+
+  socket.on('topic:join', joinTopic);
+};

--- a/src/websockets/utils.js
+++ b/src/websockets/utils.js
@@ -1,0 +1,19 @@
+const jwt = require('jsonwebtoken');
+const config = require('../config/config');
+const { User } = require('../models');
+const catchAsync = require('../utils/catchAsync');
+
+const checkAuth = catchAsync(async (event, args, next) => {
+    try {
+      const payload = jwt.verify(args.token, config.jwt.secret);
+      args.user = await User.findById(payload.sub);
+    } catch (e) {
+      return;
+    }
+
+    next();
+  });
+
+  module.exports = {
+      checkAuth,
+  }


### PR DESCRIPTION
Hey @bimalghartimagar. I think this is ready to go. 

I have added two new websocket events, `vote:new` and `thread:new`. The `vote:new` event is broadcasted whenever a new vote is submitted via the API. It sends back the corresponding Message object, with the upVotes and downVotes.

The `thread:new` event is broadcasted when a new thread is created via the API and sends back the new Thread object. For the new thread event, you'll need to send a message to `topic:join` with a topicId in the payload. This will sign up the user to receive the new thread events for that specific channel. This can be done ideally when the user clicks on a specific channel and sees the list of threads.

Let me know if you have any questions or need the return data tweaked.