### PR TITLE
Add yarn step to docker compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,4 +3,4 @@ version: '3'
 services:
   node-app:
     container_name: node-app-dev
-    command: yarn dev -L
+    command: yarn && yarn dev -L


### PR DESCRIPTION
My local environment's native build of bcrypt was conflicting with the docker environment, so I added this step to build inside docker, instead of in my env.